### PR TITLE
位置情報関連の情報を扱うLocationManagerクラスをEnvironmentObjectにしてアプリ内で共有

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Common/PilgrimageListNavigationView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Common/PilgrimageListNavigationView.swift
@@ -13,6 +13,7 @@ struct PilgrimageListNavigationView: View {
     @State var store = Store(initialState: FavoriteFeature.State()) {
         FavoriteFeature()
     }
+    @EnvironmentObject private var locationManager: LocationManager
 
     var body: some View {
         GeometryReader { geometry in
@@ -26,6 +27,7 @@ struct PilgrimageListNavigationView: View {
                                         pilgrimage: pilgrimage,
                                         store: store
                                     )
+                                    .environmentObject(locationManager)
                             ) {
                                 EmptyView()
                             }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct PilgrimageDetailView: View {
     @Environment(\.theme) private var theme
     @State private var isFavorite = false
+    @State private var isShowAlert = false
+    @EnvironmentObject private var locationManager: LocationManager
     let pilgrimage: PilgrimageInformation
     let store: StoreOf<FavoriteFeature>
 
@@ -54,10 +56,22 @@ struct PilgrimageDetailView: View {
 
                     Button {
                         // TODO: チェックイン処理
+
+                        // 位置情報許可ステータスをチェック
+                        let isAuthorized = !locationManager.isLocationPermissionDenied
+                        guard isAuthorized else {
+                            // 位置情報が許可されなかった場合
+                            isShowAlert.toggle()
+                            return
+                        }
                         print("TODO: チェックイン処理")
                     } label: {
                         Text(R.string.localizable.tabbar_check_in())
                             .frame(height: theme.margins.spacing_xl)
+                    }
+                    .alert(R.string.localizable.alert_location(), isPresented: $isShowAlert) {
+                    } message: {
+                        EmptyView()
                     }
                     .frame(maxWidth: .infinity)
                     .background(R.color.text_secondary()!.color)

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct PilgrimageListView: View {
     @Environment(\.theme) private var theme
+    @EnvironmentObject private var locationManager: LocationManager
     @State private var searchWord = ""
     @State var store = Store(initialState: SearchCandidateFeature.State()) {
         SearchCandidateFeature()
@@ -28,6 +29,7 @@ struct PilgrimageListView: View {
                     PilgrimageListNavigationView(
                         pilgrimageList: viewStore.allSearchCandidatePilgrimages
                     )
+                    .environmentObject(locationManager)
                 }
                 .onAppear {
                     viewStore.send(.resetPilgrimages)

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageCard/PilgrimageCardView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageCard/PilgrimageCardView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct PilgrimageCardView: View {
     @Environment(\.theme) private var theme
     @State private var isFavorite = false
+    @EnvironmentObject private var locationManager: LocationManager
     let pilgrimage: PilgrimageInformation
     let store: StoreOf<FavoriteFeature>
 
@@ -73,7 +74,13 @@ struct PilgrimageCardView: View {
                                 
                             }
                             
-                            NavigationLink(destination: PilgrimageDetailView(pilgrimage: pilgrimage, store: store)) {
+                            NavigationLink(
+                                destination:
+                                    PilgrimageDetailView(
+                                        pilgrimage: pilgrimage, store: store
+                                    )
+                                    .environmentObject(locationManager)
+                            ) {
                                 Text(R.string.localizable.common_btn_detail_text())
                             }
                         }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageMapView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageMapView.swift
@@ -17,7 +17,7 @@ struct PilgrimageMapView: View {
         FavoriteFeature()
     }
     @State private var isShowAlert = false
-    @StateObject private var locationManager = LocationManager()
+    @EnvironmentObject private var locationManager: LocationManager
 
     var body: some View {
         GeometryReader { geometry in
@@ -92,6 +92,7 @@ struct PilgrimageMapView: View {
                     .frame(
                         width: max(0, geometry.size.width - theme.margins.spacing_l * 2)
                     )
+                    .environmentObject(locationManager)
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageView.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 struct PilgrimageView: View {
     @Environment(\.theme) private var theme
+    @StateObject private var locationManager = LocationManager()
 
     var body: some View {
         ZStack {
             PilgrimageMapView()
+                .environmentObject(locationManager)
         }
         .navigationTitle(R.string.localizable.tabbar_pilgrimage())
         .navigationBarTitleDisplayMode(.inline)
@@ -27,7 +29,11 @@ extension PilgrimageView {
     /// NavigationBarの聖地一覧遷移ボタン
     private var pilgrimageListToolBarItem: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            NavigationLink(destination: PilgrimageListView()) {
+            NavigationLink(
+                destination: 
+                    PilgrimageListView()
+                    .environmentObject(locationManager)
+            ) {
                 Image(systemName: "list.bullet")
                     .foregroundStyle(.white)
             }


### PR DESCRIPTION
## 概要
- 位置情報関連の情報を扱うLocationManagerクラスをEnvironmentObjectにしてアプリ内で共有

## スクショ
### 位置情報利用許可
https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/c1fd46f0-20fb-4215-a718-3011cf3cfadb

### 位置情報利用拒否
https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/ba131b7f-1422-4dd4-8892-cfb9e171a975



