### PR TITLE
聖地リストを各画面に受け渡して聖地の情報を表示

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/SearchCandidateFeature.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/SearchCandidateFeature.swift
@@ -18,7 +18,7 @@ struct SearchCandidateFeature: Reducer {
         case searchPilgrimages(String)
         case startLoading
         case stopLoading
-        case resetPilgrimages
+        case resetPilgrimages(pilgrimages: [PilgrimageInformation])
         case searchAllPilgrimages // 一覧から検索
         case searchPilgrimagesResponse([PilgrimageInformation])
     }
@@ -26,9 +26,9 @@ struct SearchCandidateFeature: Reducer {
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
-            case .resetPilgrimages:
+            case let.resetPilgrimages(pilgrimages):
                 // 初回立ち上げ時 and 空文字での検索時に実行
-                state.allSearchCandidatePilgrimages = dummyPilgrimageList
+                state.allSearchCandidatePilgrimages = pilgrimages
                 return .none
 
             case let .searchPilgrimages(text):
@@ -48,7 +48,7 @@ struct SearchCandidateFeature: Reducer {
                 return .none
 
             case .searchAllPilgrimages:
-                let filteredPilgrimages = searchPilgrimages(with: state.searchText, searchTarget: dummyPilgrimageList)
+                let filteredPilgrimages = searchPilgrimages(with: state.searchText, searchTarget: state.allSearchCandidatePilgrimages)
                 return .run { send in
                     await send(.searchPilgrimagesResponse(filteredPilgrimages))
                     await send(.stopLoading)

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/LaunchScreen.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/LaunchScreen.swift
@@ -28,7 +28,7 @@ struct LaunchScreen: View {
                 }
             } else {
                 if !viewStore.state.hasError {
-                    MainView()
+                    MainView(pilgrimages: viewStore.state.pilgrimages)
                         .environment(\.theme, .system)
                 }
             }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Model/PilgrimageInformation.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Model/PilgrimageInformation.swift
@@ -46,7 +46,7 @@ struct PilgrimageInformation: Hashable, Decodable {
         case latitude
         case longitude
         case address
-        case imageURL
+        case imageURL = "image_url"
         case copyright
         case searchCandidateList = "search_candidate_list"
     }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Main/MainView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Main/MainView.swift
@@ -19,11 +19,12 @@ struct MainView: View {
     ) {
         PilgrimageDetailFeature()
     }
+    let pilgrimages: [PilgrimageInformation]
 
     var body: some View {
         TabView {
             NavigationStack {
-                PilgrimageView()
+                PilgrimageView(pilgrimages: pilgrimages)
             }
             .environmentObject(locationManager)
             .tabItem {
@@ -63,8 +64,6 @@ struct MainView: View {
     }
 }
 
-struct MainView_Previews: PreviewProvider {
-    static var previews: some View {
-        MainView()
-    }
+#Preview {
+    MainView(pilgrimages: dummyPilgrimageList)
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
@@ -23,14 +23,16 @@ struct PilgrimageDetailView: View {
             ScrollView {
                 VStack(alignment: .leading) {
                     AsyncImage(url: pilgrimage.imageURL) { image in
-                        // TODO: 聖地の画像を表示
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
                     } placeholder: {
                         // 画像取得中のプレースホルダー表示
                         Image(R.image.no_image.name)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                     }
-                    .padding(.bottom, theme.margins.spacing_m)
+                    .padding(.vertical, theme.margins.spacing_m)
 
                     HStack {
                         Text(pilgrimage.name)

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListContentView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListContentView.swift
@@ -19,8 +19,10 @@ struct PilgrimageListContentView: View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             HStack(alignment: .top, spacing: theme.margins.spacing_m) {
                 VStack {
-                    AsyncImage(url: nil) { image in
-                        // TODO: 聖地の画像を表示
+                    AsyncImage(url: pilgrimage.imageURL) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
                     } placeholder: {
                         // 画像取得中のプレースホルダー表示
                         Image(R.image.no_image.name)
@@ -44,11 +46,8 @@ struct PilgrimageListContentView: View {
                         Button {
                             viewStore.send(.favoriteAction(.updateFavoriteList(pilgrimage)))
                             viewStore.send(.favoriteAction(.toggleFavorite(pilgrimage)))
-//                            viewStore.send(.updateFavoriteList(pilgrimage))
-//                            viewStore.send(.toggleFavorite(pilgrimage))
                             withAnimation {
                                 self.isFavorite = viewStore.state.favoriteState.isFavorite
-                                //self.isFavorite = viewStore.state.isFavorite
                             }
                         } label: {
                             if isFavorite {
@@ -71,9 +70,6 @@ struct PilgrimageListContentView: View {
                 viewStore.send(.favoriteAction(.toggleFavorite(pilgrimage)))
                 viewStore.send(.favoriteAction(.fetchFavorites))
                 self.isFavorite = viewStore.state.favoriteState.isFavorite
-                //viewStore.send(.toggleFavorite(pilgrimage))
-                //viewStore.send(.fetchFavorites)
-                //self.isFavorite = viewStore.state.isFavorite
             }
         }
         .padding()

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListView.swift
@@ -14,6 +14,7 @@ struct PilgrimageListView: View {
     @State var store = Store(initialState: SearchCandidateFeature.State()) {
         SearchCandidateFeature()
     }
+    let pilgrimages: [PilgrimageInformation]
 
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -30,7 +31,7 @@ struct PilgrimageListView: View {
                     )
                 }
                 .onAppear {
-                    viewStore.send(.resetPilgrimages)
+                    viewStore.send(.resetPilgrimages(pilgrimages: pilgrimages))
                 }
                 .onChange(of: viewStore.isLoading) { newIsLoading in
                     if newIsLoading {
@@ -62,9 +63,10 @@ struct PilgrimageListView: View {
             .onSubmit {
                 // キーボードの検索ボタンが押されたときにアクションを送信
                 if !searchWord.isEmpty {
+                    viewStore.send(.resetPilgrimages(pilgrimages: pilgrimages))
                     viewStore.send(.searchPilgrimages(searchWord))
                 } else {
-                    viewStore.send(.resetPilgrimages)
+                    viewStore.send(.resetPilgrimages(pilgrimages: pilgrimages))
                 }
             }
         }
@@ -75,5 +77,5 @@ struct PilgrimageListView: View {
 }
 
 #Preview {
-    PilgrimageListView()
+    PilgrimageListView(pilgrimages: dummyPilgrimageList)
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageCard/PilgrimageCardView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageCard/PilgrimageCardView.swift
@@ -18,8 +18,11 @@ struct PilgrimageCardView: View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             HStack(spacing: theme.margins.spacing_m) {
                 VStack {
-                    AsyncImage(url: nil) { image in
-                        // TODO: 聖地の画像を表示
+                    AsyncImage(url: pilgrimage.imageURL) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+
                     } placeholder: {
                         // 画像取得中のプレースホルダー表示
                         Image(R.image.no_image.name)

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageMapView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageMap/PilgrimageMapView.swift
@@ -23,6 +23,7 @@ struct PilgrimageMapView: View {
     }
     @State private var isShowAlert = false
     @EnvironmentObject private var locationManager: LocationManager
+    let pilgrimages: [PilgrimageInformation]
 
     var body: some View {
         GeometryReader { geometry in
@@ -59,7 +60,7 @@ struct PilgrimageMapView: View {
                 .onChange(of: selectedIndex) { _ in
                     withAnimation {
                         region.center = offsetAppliedCenter(
-                            to: dummyPilgrimageList[selectedIndex].coordinate,
+                            to: pilgrimages[selectedIndex].coordinate,
                             geometry: geometry
                         )
                     }
@@ -71,13 +72,13 @@ struct PilgrimageMapView: View {
         Map(
             coordinateRegion: $region,
             showsUserLocation: true,
-            annotationItems: dummyPilgrimageList,
+            annotationItems: pilgrimages,
             annotationContent: { item in
                 let coordinate = CLLocationCoordinate2D(
                     latitude: item.coordinate.latitude,
                     longitude: item.coordinate.longitude
                 )
-                let index = dummyPilgrimageList.firstIndex(where: { $0.code == item.code }) ?? 0
+                let index = pilgrimages.firstIndex(where: { $0.code == item.code }) ?? 0
 
                 return MapAnnotation(coordinate: coordinate) {
                     Image(uiImage: R.image.map_pin()!)
@@ -91,7 +92,7 @@ struct PilgrimageMapView: View {
 
     private func pilgrimageCardsView(geometry: GeometryProxy) -> some View {
         TabView(selection: $selectedIndex) {
-            ForEach(Array(dummyPilgrimageList.enumerated()), id: \.element.id) { index, pilgrimage in
+            ForEach(Array(pilgrimages.enumerated()), id: \.element.id) { index, pilgrimage in
                 PilgrimageCardView(pilgrimage: pilgrimage, store: store)
                     .tag(index)
                     .frame(
@@ -119,6 +120,6 @@ struct PilgrimageMapView: View {
 }
 
 #Preview {
-    PilgrimageMapView()
+    PilgrimageMapView(pilgrimages: dummyPilgrimageList)
         .environmentObject(LocationManager())
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageView.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 
 struct PilgrimageView: View {
+    let pilgrimages: [PilgrimageInformation]
+    
     var body: some View {
         ZStack {
-            PilgrimageMapView()
+            PilgrimageMapView(pilgrimages: pilgrimages)
         }
         .navigationTitle(R.string.localizable.tabbar_pilgrimage())
         .navigationBarTitleDisplayMode(.inline)
@@ -27,7 +29,7 @@ extension PilgrimageView {
         ToolbarItem(placement: .topBarTrailing) {
             NavigationLink(
                 destination: 
-                    PilgrimageListView()
+                    PilgrimageListView(pilgrimages: pilgrimages)
             ) {
                 Image(systemName: "list.bullet")
                     .foregroundStyle(.white)
@@ -37,6 +39,6 @@ extension PilgrimageView {
 }
 
 #Preview {
-    PilgrimageView()
+    PilgrimageView(pilgrimages: dummyPilgrimageList)
         .environmentObject(LocationManager())
 }


### PR DESCRIPTION
## 概要
- 聖地リストを各画面に受け渡して聖地の情報を表示

## スクショ
<img width="399" alt="スクリーンショット 2024-03-03 19 41 30" src="https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/154e1d3b-7fda-4456-ab9f-f13a70abfc9d">

<img width="399" alt="スクリーンショット 2024-03-03 19 41 47" src="https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/5941cd3e-1e40-42d6-9efc-8fbc3ee7a152">


## 備考
- お気に入りとチェックインは現在はUserDefaultsで管理しているが、後でfirebaseに以降