### PR TITLE
位置情報取得許可状態なのに取得エラーアラートが出る不具合の修正

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/LocationManager.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/LocationManager.swift
@@ -29,6 +29,13 @@ final class LocationManager: NSObject, ObservableObject {
             // 位置情報を利用するか未設定の場合に利用許可を求めるアラートを表示
             locationManager.requestWhenInUseAuthorization()
         } else {
+            switch locationManager.authorizationStatus {
+            case .restricted, .denied:
+                isLocationPermissionDenied = true
+            case .authorizedWhenInUse:
+                isLocationPermissionDenied = false
+            default: break
+            }
             // ユーザーの現在地の配信を１回だけ要求する
             locationManager.startUpdatingLocation()
         }


### PR DESCRIPTION
## 概要
- 位置情報取得許可状態なのに取得エラーアラートが出る不具合の修正
- 起動時に位置情報許可状態を参照することで対応
- close #25 