### PR TITLE
求人詳細画面でお気に入りしてもインジケータが表示されない不具合の修正

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
@@ -43,7 +43,10 @@ struct PilgrimageDetailView: View {
                         Button {
                             viewStore.send(.favoriteAction(.updateFavoriteList(pilgrimage)))
                         } label: {
-                            if viewStore.state.favoriteState.favoritePilgrimages.contains(pilgrimage) {
+                            if viewStore.state.favoriteState.isLoading {
+                                // 通信中の場合、インジケータを表示
+                                ProgressView()
+                            } else if viewStore.state.favoriteState.favoritePilgrimages.contains(pilgrimage) {
                                 Image(systemName: "heart.fill")
                                     .foregroundStyle(.red)
                             } else {


### PR DESCRIPTION
## 概要
- 詳細画面にて、お気に入りボタン押下でローディングを表示
- close #28 

## スクショ

https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/2ea0d74b-34cc-4cc7-8412-11304dde50ca

