### PR TITLE
リスト画面にて、高速スクロールでエラーが出る不具合を修正

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListContentView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListContentView.swift
@@ -65,9 +65,6 @@ struct PilgrimageListContentView: View {
                         .font(theme.fonts.caption)
                 }
             }
-            .onAppear {
-                viewStore.send(.favoriteAction(.fetchFavorites))
-            }
             .onChange(of: viewStore.state.favoriteState.hasNetworkError) { hasNetworkAlert in
                 self.hasNetworkAlert = hasNetworkAlert
             }


### PR DESCRIPTION
## 概要
- 画面表示時にお気に入りリストを取得する処理を削除
- close #54 