### PR TITLE
iPadで広告が表示されないバグを修正

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Banner/BannerView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Banner/BannerView.swift
@@ -77,8 +77,12 @@ struct BannerView: UIViewControllerRepresentable {
         // MARK: - BannerViewControllerWidthDelegate methods
         func bannerViewController(_: BannerViewController, didUpdate width: CGFloat) {
             // Pass the viewWidth from Coordinator to BannerView.
+            // iPadでのAdMob広告表示エラーに対応
+            // See also https://qiita.com/SNQ-2001/items/1f19c3b6ce584ef25d6f
+            let request = GADRequest()
+            request.scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
             parent.viewWidth = width
-            parent.bannerView.load(GADRequest())
+            parent.bannerView.load(request)
         }
 
         // MARK: - GADBannerViewDelegate methods

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/NativeAdvance/NativeAdvanceViewController.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/NativeAdvance/NativeAdvanceViewController.swift
@@ -64,7 +64,12 @@ final class NativeAdvanceViewController: UIViewController {
             options: [multipleAdOptions]
         )
         adLoader.delegate = self
-        adLoader.load(GADRequest())
+
+        let request = GADRequest()
+        // iPadでのAdMob広告表示エラーに対応
+        // See also https://qiita.com/SNQ-2001/items/1f19c3b6ce584ef25d6f
+        request.scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        adLoader.load(request)
     }
 }
 


### PR DESCRIPTION
## 概要
- iPadで広告が表示されないバグを修正
- close #69 

## スクショ
| バナー広告 | ネイティブ広告 |
| ---- | ---- |
| <img width="618" alt="スクリーンショット 2024-04-20 9 30 16" src="https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/3afe9e86-da78-4d78-a68a-41c2bd9b73ee"> | <img width="618" alt="スクリーンショット 2024-04-20 9 31 22" src="https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/18644861-bfff-4eb4-bce9-bcaa5a3cabf4"> |




