### PR TITLE
検索結果をスクロールするとカクつく不具合の修正

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
-        "version" : "1.3.0"
+        "revision" : "79623dbe2c7672f5e450d8325613d231454390b3",
+        "version" : "1.3.2"
       }
     },
     {
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
-        "version" : "1.1.1"
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Common/PilgrimageListNavigationView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Common/PilgrimageListNavigationView.swift
@@ -18,43 +18,53 @@ struct PilgrimageListNavigationView: View {
     var body: some View {
         GeometryReader { geometry in
             NavigationStack {
-                List {
-                    ForEachStore(
-                        store.scope(
-                        state: \.pilgrimageSearchResults,
-                        action: \.pilgrimageRows
-                        )
-                    ) { itemStore in
-                        if itemStore.id % 5 == 0 {
-                            NativeAdvanceView()
-                                .frame(height: geometry.size.width / 3)
-                        } else {
-                            ZStack {
+                ScrollView {
+                    ScrollViewReader { proxy in
+                        LazyVStack(alignment: .leading) {
+                            ForEachStore(
+                                store.scope(
+                                    state: \.pilgrimageSearchResults,
+                                    action: \.pilgrimageRows
+                                )
+                            ) { itemStore in
+
+                                if itemStore.id % 5 == 0 {
+                                    NativeAdvanceView()
+                                        .frame(height: geometry.size.width / 3)
+                                        .padding(.vertical, 8)
+                                        .padding(.horizontal, 16)
+                                }
+
                                 NavigationLink(
                                     destination: PilgrimageDetailView(pilgrimage: itemStore.pilgrimage)
+                                        .onAppear {
+                                            store.send(
+                                                .updateScrollToIndex(scrollToIndex: itemStore.pilgrimage.id)
+                                            )
+                                        }
                                 ) {
-                                    EmptyView()
+                                    PilgrimageListContentView(
+                                        pilgrimage: itemStore.pilgrimage,
+                                        store: itemStore
+                                    )
+                                    .frame(maxHeight: geometry.size.width / 3)
+                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 16)
+                                    .id(itemStore.pilgrimage.id)
                                 }
-                                .opacity(0)
-
-                                PilgrimageListContentView(
-                                    pilgrimage: itemStore.pilgrimage,
-                                    store: itemStore
-                                )
-                                .frame(maxHeight: geometry.size.width / 3)
                             }
-                            .listRowSeparator(.hidden)
+                        }
+                        .onAppear {
+                            proxy.scrollTo(
+                                store.scrollToIndex, anchor: .center
+                            )
                         }
                     }
                 }
-                .listStyle(.plain)
             }
         }
     }
 }
-
-
-
 
 #Preview {
     PilgrimageListNavigationView(

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/FavoritePilgrimage/FavoritePilgrimageView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/FavoritePilgrimage/FavoritePilgrimageView.swift
@@ -32,30 +32,31 @@ struct FavoritePilgrimageView: View {
                                     state: \.favoritePilgrimageRows,
                                     action: \.favoritePilgrimageRows
                                 )) { itemStore in
+                                    
                                     if itemStore.id % 5 == 0 {
                                         NativeAdvanceView()
                                             .frame(height: geometry.size.width / 3)
-                                    } else {
-                                        ZStack {
-                                            NavigationLink(
-                                                destination: PilgrimageDetailView(pilgrimage: itemStore.pilgrimage)
-                                            ) {
-                                                EmptyView()
-                                            }
-                                            .opacity(0)
-
-                                            PilgrimageListContentView(
-                                                pilgrimage: itemStore.pilgrimage, 
-                                                store: itemStore
-                                            )
-                                            .frame(maxHeight: geometry.size.width / 3)
-                                        }
-                                        .listRowSeparator(.hidden)
                                     }
+
+                                    ZStack {
+                                        NavigationLink(
+                                            destination: PilgrimageDetailView(pilgrimage: itemStore.pilgrimage)
+                                        ) {
+                                            EmptyView()
+                                        }
+                                        .opacity(0)
+
+                                        PilgrimageListContentView(
+                                            pilgrimage: itemStore.pilgrimage,
+                                            store: itemStore
+                                        )
+                                        .frame(maxHeight: geometry.size.width / 3)
+                                    }
+                                    .listRowSeparator(.hidden)
                                 }
                             }
-                            .listStyle(.plain)
                         }
+                        .listStyle(.plain)
                     }
                 }
             }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListContentView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListContentView.swift
@@ -35,6 +35,8 @@ struct PilgrimageListContentView: View {
                 if let copyright = pilgrimage.copyright {
                     Text(copyright)
                         .font(theme.fonts.captionSmall)
+                        .foregroundStyle(.black)
+                        .multilineTextAlignment(.leading)
                 }
             }
 
@@ -42,6 +44,8 @@ struct PilgrimageListContentView: View {
                 HStack(alignment: .top) {
                     Text(pilgrimage.name)
                         .font(theme.fonts.bodyMedium)
+                        .foregroundStyle(.black)
+                        .multilineTextAlignment(.leading)
 
                     Spacer()
 
@@ -65,6 +69,8 @@ struct PilgrimageListContentView: View {
 
                 Text(pilgrimage.address)
                     .font(theme.fonts.caption)
+                    .foregroundStyle(.black)
+                    .multilineTextAlignment(.leading)
             }
             .onAppear {
                 store.send(.onAppear(pilgrimage))

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageList/PilgrimageListView.swift
@@ -25,17 +25,19 @@ struct PilgrimageListView: View {
                     .padding(.horizontal, theme.margins.spacing_m)
                     .background(R.color.tab_primary()!.color)
 
-                PilgrimageListNavigationView(store: store)
+                if store.isLoading {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.large)
+                    Spacer()
+                } else {
+                    PilgrimageListNavigationView(store: store)
+                }
             }
             .onAppear {
                 searchText = store.searchText
                 store.send(.onAppear(pilgrimages))
-
-                if store.searchText.isEmpty {
-                    store.send(.searchPilgrimages(""))
-                } else {
-                    store.send(.searchPilgrimages(searchText))
-                }
+                store.send(.searchPilgrimages(searchText))
             }
         }
         .navigationTitle(R.string.localizable.navbar_pilgrimage_list())
@@ -59,11 +61,7 @@ struct PilgrimageListView: View {
             .submitLabel(.search)
             .onSubmit {
                 // キーボードの検索ボタンが押されたときにアクションを送信
-                if !searchText.isEmpty {
-                    store.send(.searchPilgrimages(searchText))
-                } else {
-                    store.send(.searchPilgrimages(""))
-                }
+                store.send(.searchPilgrimages(searchText))
             }
         }
         .background(.white)


### PR DESCRIPTION
## 概要
- 検索結果をスクロールするとカクつく不具合の修正
- 聖地リストの表示されている広告が、聖地リストと入れ替わっている不具合の修正
- close #74 
- close #72 

## スクショ
| before | after |
| ---- | ---- |
| <video src = "https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/d2b0412c-69c4-4158-bf0e-a9a9c93bbbeb"> | <video src = "https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/55a88a77-3ef2-4675-b012-d1141995a7c2"> |