### PR TITLE
[お気に入り画面]詳細遷移時にスクロール位置がtopで初期化されてしまう不具合を修正

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/FavoriteFeature.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/FavoriteFeature.swift
@@ -12,6 +12,7 @@ import FirebaseFirestore
 struct FavoriteFeature {
     @ObservableState
     struct State: Equatable {
+        var scrollToIndex = 0
         var favoritePilgrimageRows = IdentifiedArrayOf<PilgrimageRowFeature.State>()
         var isLoading = false
         var favorited = false
@@ -20,6 +21,7 @@ struct FavoriteFeature {
 
     enum Action {
         case onAppear
+        case updateScrollToIndex(scrollToIndex: Int)
         case fetchFavorites
         case pilgrimageResponse(Result<[PilgrimageInformation], APIError>)
         case setLoading(Bool)
@@ -35,6 +37,9 @@ struct FavoriteFeature {
             switch action {
             case .onAppear:
                 return .send(.fetchFavorites)
+            case let .updateScrollToIndex(scrollToIndex):
+                state.scrollToIndex = scrollToIndex
+                return .none
             case .fetchFavorites:
                 return .run { send in
                     await send(.setLoading(true))

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Main/MainView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Main/MainView.swift
@@ -25,13 +25,7 @@ struct MainView: View {
             }
 
             NavigationStack {
-                FavoritePilgrimageView(
-                    store: .init(
-                        initialState: FavoriteFeature.State()
-                    ) {
-                        FavoriteFeature()
-                    }
-                )
+                FavoritePilgrimageView()
             }
             .tabItem {
                 Image(systemName: "heart.fill")


### PR DESCRIPTION
## 概要
- お気に入り画面にて、詳細遷移時にスクロール位置がtopで初期化されてしまう不具合を修正
- 詳細画面遷移時にスクロールのインデックスを保持
- 最後に詳細画面に遷移した要素が画面中央に配置されるように調整
- close #75 

## スクショ
| before | after |
| ---- | ---- |
| <video src = "https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/02d95520-d3f3-4be2-951a-3a996c129c60"> | <video src = "https://github.com/KaitoKudou/nogizaka-pilgrimage/assets/40165303/a06dc4e8-10d7-4f41-9657-df8730f82e57"> |