### PR TITLE
MobileAdsを最新にアップデート

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -1053,8 +1053,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cybozu/LicenseList.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
+				kind = exactVersion;
+				version = 2.1.0;
 			};
 		};
 		E747728D2D958B0100F659EF /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
@@ -1062,7 +1062,7 @@
 			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 12.2.0;
+				minimumVersion = 12.8.0;
 			};
 		};
 		E7B9CD552B8E26E9003FAB19 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -15,16 +15,16 @@
 		E71A827D2BE20F6900C16FEE /* IconLicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71A827C2BE20F6900C16FEE /* IconLicenseView.swift */; };
 		E71D093B2AF39076009C132E /* PilgrimageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71D093A2AF39076009C132E /* PilgrimageDetailView.swift */; };
 		E7235A72297D75D500E1339A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7235A71297D75D500E1339A /* Theme.swift */; };
-		E725056F2BB70F8D002BFB34 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = E725056E2BB70F8D002BFB34 /* GoogleMobileAds */; };
 		E72505732BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72505722BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift */; };
 		E72505752BB71786002BFB34 /* BannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72505742BB71786002BFB34 /* BannerViewController.swift */; };
-		E72505772BB717FA002BFB34 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72505762BB717FA002BFB34 /* BannerView.swift */; };
 		E73E09122965C21E00A1204E /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73E09112965C21E00A1204E /* MainView.swift */; };
 		E73E09182965C43000A1204E /* CheckInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73E09172965C43000A1204E /* CheckInView.swift */; };
 		E73E091B2965C77E00A1204E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E73E091A2965C77E00A1204E /* Colors.xcassets */; };
 		E73E091E2965CACA00A1204E /* PilgrimageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73E091D2965CACA00A1204E /* PilgrimageView.swift */; };
 		E73E092E2965D18700A1204E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E73E09302965D18700A1204E /* Localizable.strings */; };
 		E74719F22AF93A31004C2D4D /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74719F12AF93A31004C2D4D /* MenuView.swift */; };
+		E747728F2D958B0100F659EF /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = E747728E2D958B0100F659EF /* GoogleMobileAds */; };
+		E74772912D95966B00F659EF /* BannerViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74772902D95966B00F659EF /* BannerViewContainer.swift */; };
 		E74934462959F20E0045AE39 /* nogizaka_pilgrimageApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74934452959F20E0045AE39 /* nogizaka_pilgrimageApp.swift */; };
 		E749344A2959F2120045AE39 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E74934492959F2120045AE39 /* Assets.xcassets */; };
 		E749344D2959F2120045AE39 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E749344C2959F2120045AE39 /* Preview Assets.xcassets */; };
@@ -99,13 +99,13 @@
 		E72505702BB710F6002BFB34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E72505722BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewControllerWidthDelegate.swift; sourceTree = "<group>"; };
 		E72505742BB71786002BFB34 /* BannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewController.swift; sourceTree = "<group>"; };
-		E72505762BB717FA002BFB34 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		E73E09112965C21E00A1204E /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		E73E09172965C43000A1204E /* CheckInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInView.swift; sourceTree = "<group>"; };
 		E73E091A2965C77E00A1204E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		E73E091D2965CACA00A1204E /* PilgrimageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimageView.swift; sourceTree = "<group>"; };
 		E73E092F2965D18700A1204E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E74719F12AF93A31004C2D4D /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
+		E74772902D95966B00F659EF /* BannerViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewContainer.swift; sourceTree = "<group>"; };
 		E74934422959F20E0045AE39 /* nogizaka-pilgrimage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "nogizaka-pilgrimage.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E74934452959F20E0045AE39 /* nogizaka_pilgrimageApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = nogizaka_pilgrimageApp.swift; sourceTree = "<group>"; };
 		E74934492959F2120045AE39 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -158,10 +158,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E747728F2D958B0100F659EF /* GoogleMobileAds in Frameworks */,
 				E7CB5D5B2B021BCB001A1CDB /* ComposableArchitecture in Frameworks */,
 				E7B9CD592B8E26E9003FAB19 /* FirebaseFirestore in Frameworks */,
 				E710931D2BE13DAA005482F7 /* LicenseList in Frameworks */,
-				E725056F2BB70F8D002BFB34 /* GoogleMobileAds in Frameworks */,
 				E7FD73D42959FCD400347BA4 /* Rswift in Frameworks */,
 				E7B9CD572B8E26E9003FAB19 /* FirebaseAnalytics in Frameworks */,
 			);
@@ -240,7 +240,7 @@
 			children = (
 				E72505722BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift */,
 				E72505742BB71786002BFB34 /* BannerViewController.swift */,
-				E72505762BB717FA002BFB34 /* BannerView.swift */,
+				E74772902D95966B00F659EF /* BannerViewContainer.swift */,
 			);
 			path = Banner;
 			sourceTree = "<group>";
@@ -498,8 +498,8 @@
 				E7CB5D5A2B021BCB001A1CDB /* ComposableArchitecture */,
 				E7B9CD562B8E26E9003FAB19 /* FirebaseAnalytics */,
 				E7B9CD582B8E26E9003FAB19 /* FirebaseFirestore */,
-				E725056E2BB70F8D002BFB34 /* GoogleMobileAds */,
 				E710931C2BE13DAA005482F7 /* LicenseList */,
+				E747728E2D958B0100F659EF /* GoogleMobileAds */,
 			);
 			productName = "nogizaka-pilgrimage";
 			productReference = E74934422959F20E0045AE39 /* nogizaka-pilgrimage.app */;
@@ -577,8 +577,8 @@
 				E7FD73D22959FCD400347BA4 /* XCRemoteSwiftPackageReference "R.swift.Library" */,
 				E7CB5D592B021BCB001A1CDB /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 				E7B9CD552B8E26E9003FAB19 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				E725056D2BB70F8D002BFB34 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 				E710931B2BE13DAA005482F7 /* XCRemoteSwiftPackageReference "LicenseList" */,
+				E747728D2D958B0100F659EF /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 			);
 			productRefGroup = E74934432959F20E0045AE39 /* Products */;
 			projectDirPath = "";
@@ -662,7 +662,6 @@
 				E73E09122965C21E00A1204E /* MainView.swift in Sources */,
 				E74719F22AF93A31004C2D4D /* MenuView.swift in Sources */,
 				E79F3E952B7A1C8E00ABCCD8 /* CheckInFeature.swift in Sources */,
-				E72505772BB717FA002BFB34 /* BannerView.swift in Sources */,
 				E74934462959F20E0045AE39 /* nogizaka_pilgrimageApp.swift in Sources */,
 				E75907A92AD58F5E009327A8 /* ThemeEnvironmentKey.swift in Sources */,
 				E76BF15E2BD1630C00A1CB97 /* NativeAdvanceViewController.swift in Sources */,
@@ -686,6 +685,7 @@
 				E7C11D40295AF19A0051A1B9 /* R.generated.swift in Sources */,
 				E73E091E2965CACA00A1204E /* PilgrimageView.swift in Sources */,
 				E72505732BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift in Sources */,
+				E74772912D95966B00F659EF /* BannerViewContainer.swift in Sources */,
 				E7235A72297D75D500E1339A /* Theme.swift in Sources */,
 				E76D0BD42AD557F000D6BB2B /* Theme+BarAppearance.swift in Sources */,
 				E78D446A2AF8EBBD008D5550 /* PilgrimageListContentView.swift in Sources */,
@@ -1057,12 +1057,12 @@
 				minimumVersion = 0.7.0;
 			};
 		};
-		E725056D2BB70F8D002BFB34 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+		E747728D2D958B0100F659EF /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 11.2.0;
+				minimumVersion = 12.2.0;
 			};
 		};
 		E7B9CD552B8E26E9003FAB19 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
@@ -1097,9 +1097,9 @@
 			package = E710931B2BE13DAA005482F7 /* XCRemoteSwiftPackageReference "LicenseList" */;
 			productName = LicenseList;
 		};
-		E725056E2BB70F8D002BFB34 /* GoogleMobileAds */ = {
+		E747728E2D958B0100F659EF /* GoogleMobileAds */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E725056D2BB70F8D002BFB34 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			package = E747728D2D958B0100F659EF /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
 			productName = GoogleMobileAds;
 		};
 		E7B9CD562B8E26E9003FAB19 /* FirebaseAnalytics */ = {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "3ab11c6ac161bcd744b0e3b57d7d684583450839ca14cfd226041ba8d32f0866",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
-        "version" : "1.2022062300.0"
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
-        "version" : "10.18.1"
+        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
+        "version" : "10.19.2"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "f91c8167141d0279726c6f6d9d4a47c026785cbc",
-        "version" : "10.21.0"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "cb8617fab75d181270a1d8f763f26b15c73e2e1e",
-        "version" : "10.21.0"
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
       }
     },
     {
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "a732a4b47f59e4f725a2ea10f0c77e93a7131117",
-        "version" : "9.3.0"
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
       }
     },
     {
@@ -59,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
-        "version" : "7.12.1"
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
       }
     },
     {
@@ -68,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
-        "version" : "1.49.1"
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
       }
     },
     {
@@ -212,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "5ff977255c2ba5844e7e9da779f1f2a5a00e0028",
-        "version" : "11.2.0"
+        "revision" : "ab4c3ec7546c7566fe49918fc9461df44e015537",
+        "version" : "12.2.0"
       }
     },
     {
@@ -221,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
       "state" : {
-        "revision" : "cfe8b2ae16b9bc81f4cdf1d1a12a01a452489c32",
-        "version" : "2.3.0"
+        "revision" : "708a282840c2171ee63bd93b87afa49fe507d70e",
+        "version" : "2.7.0"
       }
     },
     {
@@ -271,5 +272,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cybozu/LicenseList.git",
       "state" : {
-        "revision" : "0828b88c1a6130d56ede2cc6c41ec50068a7ebd6",
-        "version" : "0.7.0"
+        "revision" : "a0a1784aa60dcdafbc30cb2ffbac90544b46100a",
+        "version" : "2.1.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "ab4c3ec7546c7566fe49918fc9461df44e015537",
-        "version" : "12.2.0"
+        "revision" : "49efd19f8f4bbe130de7e2ee9e061d202a9a2a8b",
+        "version" : "12.8.0"
       }
     },
     {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Banner/BannerViewContainer.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Banner/BannerViewContainer.swift
@@ -1,8 +1,8 @@
 //
-//  BannerView.swift
+//  BannerViewContainer.swift
 //  nogizaka-pilgrimage
 //
-//  Created by 工藤 海斗 on 2024/03/30.
+//  Created by 工藤 海斗 on 2025/03/27.
 //
 
 import GoogleMobileAds
@@ -25,9 +25,9 @@ enum AdUnitID {
     }
 }
 
-struct BannerView: UIViewControllerRepresentable {
+struct BannerViewContainer: UIViewControllerRepresentable {
     @State private var viewWidth: CGFloat = .zero
-    private let bannerView = GADBannerView()
+    private let bannerView = BannerView()
     let adUnitID: AdUnitID
 
     init(adUnitID: AdUnitID) {
@@ -55,22 +55,22 @@ struct BannerView: UIViewControllerRepresentable {
         guard viewWidth != .zero else { return }
 
         // Request a banner ad with the updated viewWidth.
-        bannerView.adSize = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(viewWidth)
-        bannerView.load(GADRequest())
+        bannerView.adSize = currentOrientationAnchoredAdaptiveBanner(width: viewWidth)
+        bannerView.load(Request())
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
 
-    static func getAdSize(width: CGFloat) -> GADAdSize {
-        return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width)
+    static func getAdSize(width: CGFloat) -> AdSize {
+        return currentOrientationAnchoredAdaptiveBanner(width: width)
     }
 
-    class Coordinator: NSObject, BannerViewControllerWidthDelegate, GADBannerViewDelegate {
-        let parent: BannerView
+    class Coordinator: NSObject, BannerViewControllerWidthDelegate, BannerViewDelegate {
+        let parent: BannerViewContainer
 
-        init(_ parent: BannerView) {
+        init(_ parent: BannerViewContainer) {
             self.parent = parent
         }
 
@@ -79,14 +79,14 @@ struct BannerView: UIViewControllerRepresentable {
             // Pass the viewWidth from Coordinator to BannerView.
             // iPadでのAdMob広告表示エラーに対応
             // See also https://qiita.com/SNQ-2001/items/1f19c3b6ce584ef25d6f
-            let request = GADRequest()
+            let request = Request()
             request.scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
             parent.viewWidth = width
             parent.bannerView.load(request)
         }
 
         // MARK: - GADBannerViewDelegate methods
-        func bannerView(_: GADBannerView, didFailToReceiveAdWithError error: Error) {
+        func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: any Error) {
             // エラー時にも広告ビューのサイズを設定し直す
             DispatchQueue.main.async {
                 self.parent.bannerView.frame = CGRect(origin: .zero, size: CGSize(width: self.parent.viewWidth, height: 60))

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Banner/BannerViewContainer.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Banner/BannerViewContainer.swift
@@ -49,6 +49,10 @@ struct BannerViewContainer: UIViewControllerRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
+    
+    static func getAdSize(width: CGFloat) -> AdSize {
+        return currentOrientationAnchoredAdaptiveBanner(width: width)
+    }
 
     class Coordinator: NSObject, BannerViewControllerWidthDelegate, BannerViewDelegate {
         let parent: BannerViewContainer

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/CheckIn/CheckInView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/CheckIn/CheckInView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct CheckInView: View {
     @Environment(\.theme) private var theme
     @Bindable var store: StoreOf<CheckInFeature>
-    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     init(store: StoreOf<CheckInFeature>) {
         self.store = store
@@ -29,10 +28,7 @@ struct CheckInView: View {
                 Spacer()
 
                 BannerViewContainer(adUnitID: .checkIn)
-                    .frame(
-                        width: adSize.size.width,
-                        height: adSize.size.height
-                    )
+                    .frame(height: 50)
             }
         }
         .onAppear {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/CheckIn/CheckInView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/CheckIn/CheckInView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct CheckInView: View {
     @Environment(\.theme) private var theme
     @Bindable var store: StoreOf<CheckInFeature>
-    private let adSize = BannerView.getAdSize(width: UIScreen.main.bounds.width)
+    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     init(store: StoreOf<CheckInFeature>) {
         self.store = store
@@ -28,7 +28,7 @@ struct CheckInView: View {
 
                 Spacer()
 
-                BannerView(adUnitID: .checkIn)
+                BannerViewContainer(adUnitID: .checkIn)
                     .frame(
                         width: adSize.size.width,
                         height: adSize.size.height

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/CheckIn/CheckInView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/CheckIn/CheckInView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CheckInView: View {
     @Environment(\.theme) private var theme
     @Bindable var store: StoreOf<CheckInFeature>
+    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     init(store: StoreOf<CheckInFeature>) {
         self.store = store
@@ -28,7 +29,7 @@ struct CheckInView: View {
                 Spacer()
 
                 BannerViewContainer(adUnitID: .checkIn)
-                    .frame(height: 50)
+                    .frame(width: adSize.size.width, height: adSize.size.height)
             }
         }
         .onAppear {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Menu/MenuView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Menu/MenuView.swift
@@ -47,7 +47,7 @@ struct MenuView: View {
     @Environment(\.theme) private var theme
     @Bindable var store: StoreOf<MenuFeature>
     @State private var menuItems: [MenuSection: [MenuItem]] = [:]
-    private let adSize = BannerView.getAdSize(width: UIScreen.main.bounds.width)
+    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     init(store: StoreOf<MenuFeature>) {
         self.store = store
@@ -68,7 +68,7 @@ struct MenuView: View {
                     }
                 }
 
-                BannerView(adUnitID: .menu)
+                BannerViewContainer(adUnitID: .menu)
                     .frame(
                         width: adSize.size.width,
                         height: adSize.size.height

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Menu/MenuView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Menu/MenuView.swift
@@ -47,6 +47,7 @@ struct MenuView: View {
     @Environment(\.theme) private var theme
     @Bindable var store: StoreOf<MenuFeature>
     @State private var menuItems: [MenuSection: [MenuItem]] = [:]
+    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     init(store: StoreOf<MenuFeature>) {
         self.store = store
@@ -65,7 +66,7 @@ struct MenuView: View {
         VStack(spacing: .zero) {
             menuListView
             BannerViewContainer(adUnitID: .menu)
-                .frame(height: 50)
+                .frame(width: adSize.size.width, height: adSize.size.height)
         }
         .onAppear {
             store.send(.onAppear)

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/NativeAdvance/NativeAdvanceViewController.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/NativeAdvance/NativeAdvanceViewController.swift
@@ -9,8 +9,8 @@ import GoogleMobileAds
 
 final class NativeAdvanceViewController: UIViewController {
     private var heightConstraint: NSLayoutConstraint?
-    private var nativeAdView: GADNativeAdView!
-    private var adLoader: GADAdLoader!
+    private var nativeAdView: NativeAdView!
+    private var adLoader: AdLoader!
     private let adUnitID = "ca-app-pub-4288570549847775/6418050522"
 
     override func viewDidLoad() {
@@ -18,7 +18,7 @@ final class NativeAdvanceViewController: UIViewController {
 
         guard
             let nibObjects = Bundle.main.loadNibNamed("NativeAdView", owner: nil, options: nil),
-            let adView = nibObjects.first as? GADNativeAdView
+            let adView = nibObjects.first as? NativeAdView
         else {
             return assert(false, "Could not load nib file for adView")
         }
@@ -26,7 +26,7 @@ final class NativeAdvanceViewController: UIViewController {
         refreshAd()
     }
 
-    func setAdView(_ view: GADNativeAdView) {
+    func setAdView(_ view: NativeAdView) {
         nativeAdView = view
         nativeAdView.backgroundColor = .white
 
@@ -54,10 +54,10 @@ final class NativeAdvanceViewController: UIViewController {
     }
 
     func refreshAd() {
-        let multipleAdOptions = GADMultipleAdsAdLoaderOptions()
+        let multipleAdOptions = MultipleAdsAdLoaderOptions()
         multipleAdOptions.numberOfAds = 1;
 
-        adLoader = GADAdLoader(
+        adLoader = AdLoader(
             adUnitID: adUnitID, 
             rootViewController: self,
             adTypes: [.native],
@@ -65,7 +65,7 @@ final class NativeAdvanceViewController: UIViewController {
         )
         adLoader.delegate = self
 
-        let request = GADRequest()
+        let request = Request()
         // iPadでのAdMob広告表示エラーに対応
         // See also https://qiita.com/SNQ-2001/items/1f19c3b6ce584ef25d6f
         request.scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
@@ -73,8 +73,8 @@ final class NativeAdvanceViewController: UIViewController {
     }
 }
 
-extension NativeAdvanceViewController: GADNativeAdDelegate, GADNativeAdLoaderDelegate {
-    func adLoader(_ adLoader: GADAdLoader, didReceive nativeAd: GADNativeAd) {
+extension NativeAdvanceViewController: NativeAdDelegate, NativeAdLoaderDelegate {
+    func adLoader(_ adLoader: AdLoader, didReceive nativeAd: NativeAd) {
         nativeAd.delegate = self
 
         (nativeAdView.headlineView as? UILabel)?.text = nativeAd.headline
@@ -92,7 +92,7 @@ extension NativeAdvanceViewController: GADNativeAdDelegate, GADNativeAdLoaderDel
         nativeAdView.nativeAd = nativeAd
     }
 
-    func adLoader(_ adLoader: GADAdLoader, didFailToReceiveAdWithError error: Error) {
+    func adLoader(_ adLoader: AdLoader, didFailToReceiveAdWithError error: Error) {
         print("\(adLoader) failed with error: \(error.localizedDescription)")
     }
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
@@ -19,7 +19,7 @@ struct PilgrimageDetailView: View {
         PilgrimageDetailFeature()
     }
     let pilgrimage: PilgrimageInformation
-    private let adSize = BannerView.getAdSize(width: UIScreen.main.bounds.width)
+    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     var body: some View {
         VStack {
@@ -115,7 +115,7 @@ struct PilgrimageDetailView: View {
                 }
             }
 
-            BannerView(adUnitID: .pilgrimageDetail)
+            BannerViewContainer(adUnitID: .pilgrimageDetail)
                 .frame(
                     width: adSize.size.width,
                     height: adSize.size.height

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
@@ -18,6 +18,7 @@ struct PilgrimageDetailView: View {
     ) {
         PilgrimageDetailFeature()
     }
+    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
     let pilgrimage: PilgrimageInformation
 
     var body: some View {
@@ -115,7 +116,7 @@ struct PilgrimageDetailView: View {
             }
 
             BannerViewContainer(adUnitID: .pilgrimageDetail)
-                .frame(height: 50)
+                .frame(width: adSize.size.width, height: adSize.size.height)
         }
         .onAppear {
             store.send(.onAppear(pilgrimage))

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/View/Pilgrimage/PilgrimageDetail/PilgrimageDetailView.swift
@@ -19,7 +19,6 @@ struct PilgrimageDetailView: View {
         PilgrimageDetailFeature()
     }
     let pilgrimage: PilgrimageInformation
-    private let adSize = BannerViewContainer.getAdSize(width: UIScreen.main.bounds.width)
 
     var body: some View {
         VStack {
@@ -116,10 +115,7 @@ struct PilgrimageDetailView: View {
             }
 
             BannerViewContainer(adUnitID: .pilgrimageDetail)
-                .frame(
-                    width: adSize.size.width,
-                    height: adSize.size.height
-                )
+                .frame(height: 50)
         }
         .onAppear {
             store.send(.onAppear(pilgrimage))

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/nogizaka_pilgrimageApp.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/nogizaka_pilgrimageApp.swift
@@ -12,7 +12,7 @@ import SwiftUI
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        MobileAds.shared.start(completionHandler: nil)
         FirebaseApp.configure()
         return true
     }


### PR DESCRIPTION
# 概要
- GoogleMobileAdsを最新の12.8.0にアップデート
  - [これ](https://developers.google.com/admob/ios/migration?hl=ja)を見ながらマイグレーション