### PR TITLE
FavoriteRepository + DataStore を作成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,16 @@ final class SomeViewModel {
 
 ```swift
 @DependencyClient
-struct SomeClient: DependencyKey {
-    static var liveValue = Self(
-        fetchItems: { /* Firebase 実装 */ }
-    )
-
+struct SomeClient {
     var fetchItems: () async throws -> [Item]
+}
+
+extension SomeClient: DependencyKey {
+    static let liveValue: Self = {
+        return .init(
+            fetchItems: { /* Firebase 実装 */ }
+        )
+    }()
 }
 ```
 
@@ -82,7 +86,7 @@ Domain/           # Domain層（ビジネスエンティティ・ルール）
 │   └── APIError.swift
 ├── UseCase/
 │   └── CheckInUseCase.swift      # struct定義 + liveValue
-└── Repository/                   # @DependencyClient struct（インターフェース）
+└── RepositoryProtocol/            # @DependencyClient struct（インターフェース）
     ├── PilgrimageRepository.swift
     ├── CheckInRepository.swift
     └── FavoriteRepository.swift
@@ -97,7 +101,8 @@ Data/             # Data層（Repository実装・DataStore）
     │   ├── PilgrimageRemoteDataStore.swift
     │   ├── CheckInRemoteDataStore.swift
     │   └── FavoriteRemoteDataStore.swift
-    └── Cache/                    # Firebaseキャッシュ対応時に追加
+    └── Local/                    # ローカルキャッシュ（インメモリ → SwiftData予定）
+        └── FavoriteLocalDataStore.swift
 
 Utility/          # 既存のまま（LocationManager, Theme等）
 ```
@@ -119,7 +124,7 @@ Feature → Domain → Data
 
 ### Repositoryの指針
 
-- `Domain/Repository/` — `@DependencyClient` struct 定義（インターフェース）
+- `Domain/RepositoryProtocol/` — `@DependencyClient` struct 定義（インターフェース）
 - `Data/Repository/` — `extension + liveValue`（Firestore実装）
 - 読み取りも書き込みも Repository が担う（UseCase 経由不要）
 
@@ -140,4 +145,5 @@ Swift Package Manager を使用。TCA 廃止後は `Package.swift` に直接 `sw
 
 ## Firebase キャッシュ方針
 
-（TCA 剥がし完了後に決定・追記する）
+- Phase 1（実装済み）: インメモリキャッシュ（`FavoriteLocalDataStore` — actor ベース）
+- Phase 2（予定）: SwiftData 導入、PilgrimageRepository 作成、お気に入りを ID のみ保持に変更

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		E7235A72297D75D500E1339A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7235A71297D75D500E1339A /* Theme.swift */; };
 		E72505732BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72505722BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift */; };
 		E72505752BB71786002BFB34 /* BannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72505742BB71786002BFB34 /* BannerViewController.swift */; };
+		E72EA33B2F55E7A3007BFC81 /* FavoriteLocalDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA33A2F55E7A3007BFC81 /* FavoriteLocalDataStore.swift */; };
+		E72EA33D2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */; };
+		E72EA33F2F55E7D2007BFC81 /* FavoriteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */; };
+		E72EA3412F55E7DF007BFC81 /* FavoriteRepository+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */; };
 		E73E09122965C21E00A1204E /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73E09112965C21E00A1204E /* MainView.swift */; };
 		E73E091B2965C77E00A1204E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E73E091A2965C77E00A1204E /* Colors.xcassets */; };
 		E73E092E2965D18700A1204E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E73E09302965D18700A1204E /* Localizable.strings */; };
@@ -96,6 +100,10 @@
 		E72505702BB710F6002BFB34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E72505722BB716EB002BFB34 /* BannerViewControllerWidthDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewControllerWidthDelegate.swift; sourceTree = "<group>"; };
 		E72505742BB71786002BFB34 /* BannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewController.swift; sourceTree = "<group>"; };
+		E72EA33A2F55E7A3007BFC81 /* FavoriteLocalDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteLocalDataStore.swift; sourceTree = "<group>"; };
+		E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRemoteDataStore.swift; sourceTree = "<group>"; };
+		E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRepository.swift; sourceTree = "<group>"; };
+		E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FavoriteRepository+Live.swift"; sourceTree = "<group>"; };
 		E73E09112965C21E00A1204E /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		E73E091A2965C77E00A1204E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		E73E092F2965D18700A1204E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -232,6 +240,64 @@
 			path = Banner;
 			sourceTree = "<group>";
 		};
+		E72EA3332F55D514007BFC81 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		E72EA3342F55D514007BFC81 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA3372F55E75A007BFC81 /* DataStore */,
+				E72EA3332F55D514007BFC81 /* Repository */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		E72EA3352F55D530007BFC81 /* RepositoryProtocol */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */,
+			);
+			path = RepositoryProtocol;
+			sourceTree = "<group>";
+		};
+		E72EA3362F55D530007BFC81 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA3352F55D530007BFC81 /* RepositoryProtocol */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		E72EA3372F55E75A007BFC81 /* DataStore */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA3382F55E76C007BFC81 /* Local */,
+				E72EA3392F55E77E007BFC81 /* Remote */,
+			);
+			path = DataStore;
+			sourceTree = "<group>";
+		};
+		E72EA3382F55E76C007BFC81 /* Local */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA33A2F55E7A3007BFC81 /* FavoriteLocalDataStore.swift */,
+			);
+			path = Local;
+			sourceTree = "<group>";
+		};
+		E72EA3392F55E77E007BFC81 /* Remote */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */,
+			);
+			path = Remote;
+			sourceTree = "<group>";
+		};
 		E73E090F2965C1FC00A1204E /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -293,6 +359,8 @@
 				E74934452959F20E0045AE39 /* nogizaka_pilgrimageApp.swift */,
 				E7FDAA0D2AE177140056AA5B /* Extension */,
 				E7235A70297D75B000E1339A /* Utility */,
+				E72EA3342F55D514007BFC81 /* Data */,
+				E72EA3362F55D530007BFC81 /* Domain */,
 				E7178E832B073863008C85A3 /* Feature */,
 				E73E091C2965CA0A00A1204E /* Resource */,
 				E7FDA9FE2ADFDDA10056AA5B /* Model */,
@@ -725,8 +793,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7B931462F473AA900B94C75 /* MenuViewModel.swift in Sources */,
+				E72EA33B2F55E7A3007BFC81 /* FavoriteLocalDataStore.swift in Sources */,
 				E757BB042E8AD58500035318 /* ReadableContentGuideModifier.swift in Sources */,
 				E795AACE2F5055B40062C9CE /* PilgrimageListView.swift in Sources */,
+				E72EA33D2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift in Sources */,
 				E7FDAA112AE177CB0056AA5B /* UIColorExtension.swift in Sources */,
 				E7B931432F46053A00B94C75 /* IconLicenseView.swift in Sources */,
 				E795AAC82F50558E0062C9CE /* PilgrimageCardViewModel.swift in Sources */,
@@ -757,6 +827,7 @@
 				E795AAB52F4DEA390062C9CE /* FavoriteViewModel.swift in Sources */,
 				E7B931482F4749AB00B94C75 /* MenuView.swift in Sources */,
 				E7FDAA172AE230310056AA5B /* UINavigationControllerExtension.swift in Sources */,
+				E72EA33F2F55E7D2007BFC81 /* FavoriteRepository.swift in Sources */,
 				E795AAD02F5055BE0062C9CE /* PilgrimageListContentView.swift in Sources */,
 				E7C11D40295AF19A0051A1B9 /* R.generated.swift in Sources */,
 				E795AABC2F4F37830062C9CE /* LaunchViewModel.swift in Sources */,
@@ -767,6 +838,7 @@
 				E7235A72297D75D500E1339A /* Theme.swift in Sources */,
 				E76D0BD42AD557F000D6BB2B /* Theme+BarAppearance.swift in Sources */,
 				E7FDAA062AE029190056AA5B /* CurrentLocationButton.swift in Sources */,
+				E72EA3412F55E7DF007BFC81 /* FavoriteRepository+Live.swift in Sources */,
 				E7FDAA002ADFDDFB0056AA5B /* PilgrimageInformation.swift in Sources */,
 				E76BF1652BD16FE700A1CB97 /* NativeAdvanceView.swift in Sources */,
 			);

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Local/FavoriteLocalDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Local/FavoriteLocalDataStore.swift
@@ -1,0 +1,38 @@
+//
+//  FavoriteLocalDataStore.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct FavoriteLocalDataStore {
+    var getAll: () async -> [PilgrimageInformation]?
+    var setAll: (_ pilgrimages: [PilgrimageInformation]) async -> Void
+    var add: (_ pilgrimage: PilgrimageInformation) async -> Void
+    var remove: (_ id: Int) async -> Void
+}
+
+extension FavoriteLocalDataStore: DependencyKey {
+    static let liveValue: Self = {
+        let storage = FavoriteLocalStorage()
+        return .init(
+            getAll: { await storage.getAll() },
+            setAll: { await storage.setAll($0) },
+            add: { await storage.add($0) },
+            remove: { await storage.remove($0) }
+        )
+    }()
+}
+
+private actor FavoriteLocalStorage {
+    private var pilgrimages: [PilgrimageInformation]?
+
+    func getAll() -> [PilgrimageInformation]? { pilgrimages }
+    func setAll(_ items: [PilgrimageInformation]) { pilgrimages = items }
+    func add(_ item: PilgrimageInformation) { pilgrimages?.append(item) }
+    func remove(_ id: Int) { pilgrimages?.removeAll { $0.id == id } }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/FavoriteRemoteDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/FavoriteRemoteDataStore.swift
@@ -1,0 +1,49 @@
+//
+//  FavoriteRemoteDataStore.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+import FirebaseFirestore
+import UIKit
+
+@DependencyClient
+struct FavoriteRemoteDataStore {
+    var fetchAll: () async throws -> [PilgrimageInformation]
+    var exists: (_ name: String) async throws -> Bool
+    var add: (_ pilgrimage: PilgrimageInformation) async throws -> Void
+    var remove: (_ name: String) async throws -> Void
+}
+
+extension FavoriteRemoteDataStore: DependencyKey {
+    static let liveValue: Self = {
+        return .init(
+            fetchAll: {
+                let snapshot = try await collectionRef().getDocuments()
+                return try snapshot.documents.map { try $0.data(as: PilgrimageInformation.self) }
+            },
+            exists: { name in
+                let snapshot = try await collectionRef().getDocuments()
+                return snapshot.documents.contains { $0.documentID == name }
+            },
+            add: { pilgrimage in
+                let ref = await collectionRef().document(pilgrimage.name)
+                try ref.setData(from: pilgrimage)
+            },
+            remove: { name in
+                try await collectionRef().document(name).delete()
+            }
+        )
+    }()
+
+    private static func collectionRef() async -> CollectionReference {
+        let uuid = await UIDevice.current.identifierForVendor!.uuidString
+        return Firestore.firestore()
+            .collection("favorite-list")
+            .document(uuid)
+            .collection("list")
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/FavoriteRepository+Live.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/FavoriteRepository+Live.swift
@@ -1,0 +1,63 @@
+//
+//  FavoriteRepository+Live.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import FirebaseFirestore
+
+extension FavoriteRepository: DependencyKey {
+    static let liveValue: Self = {
+        @Dependency(FavoriteRemoteDataStore.self) var remoteDataStore
+        @Dependency(FavoriteLocalDataStore.self) var localDataStore
+
+        return .init(
+            fetchFavorites: {
+                do {
+                    let result = try await remoteDataStore.fetchAll()
+                    await localDataStore.setAll(result)
+                    return result
+                } catch {
+                    throw mapError(error, to: .fetchFavoritePilgrimagesError)
+                }
+            },
+            isFavorited: { name in
+                if let cached = await localDataStore.getAll() {
+                    return cached.contains { $0.name == name }
+                }
+                do {
+                    let result = try await remoteDataStore.fetchAll()
+                    await localDataStore.setAll(result)
+                    return result.contains { $0.name == name }
+                } catch {
+                    throw mapError(error, to: .fetchFavoritePilgrimagesError)
+                }
+            },
+            addFavorite: { pilgrimage in
+                do {
+                    try await remoteDataStore.add(pilgrimage)
+                    await localDataStore.add(pilgrimage)
+                } catch {
+                    throw mapError(error, to: .updateFavoritePilgrimagesError)
+                }
+            },
+            removeFavorite: { pilgrimage in
+                do {
+                    try await remoteDataStore.remove(pilgrimage.name)
+                    await localDataStore.remove(pilgrimage.id)
+                } catch {
+                    throw mapError(error, to: .updateFavoritePilgrimagesError)
+                }
+            }
+        )
+    }()
+
+    private static func mapError(_ error: Error, to apiError: APIError) -> APIError {
+        if (error as NSError).domain == FirestoreErrorDomain {
+            return apiError
+        }
+        return .unknownError
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/FavoriteRepository.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/FavoriteRepository.swift
@@ -1,0 +1,17 @@
+//
+//  FavoriteRepository.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct FavoriteRepository {
+    var fetchFavorites: () async throws -> [PilgrimageInformation]
+    var isFavorited: (_ name: String) async throws -> Bool
+    var addFavorite: (_ pilgrimage: PilgrimageInformation) async throws -> Void
+    var removeFavorite: (_ pilgrimage: PilgrimageInformation) async throws -> Void
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Favorite/FavoriteViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Favorite/FavoriteViewModel.swift
@@ -6,12 +6,14 @@
 //
 
 import Dependencies
-import FirebaseFirestore
+import Foundation
 
 @Observable
 final class FavoriteViewModel {
     @ObservationIgnored
     @Dependency(\.networkMonitor) var networkMonitor
+    @ObservationIgnored
+    @Dependency(FavoriteRepository.self) var favoriteRepository
 
     var favoritePilgrimages: [PilgrimageInformation] = []
     var isLoading = false
@@ -31,23 +33,12 @@ final class FavoriteViewModel {
 
         do {
             try await networkMonitor.monitorNetwork()
-
-            let uuid = await UIDevice.current.identifierForVendor!.uuidString
-            let querySnapshot = try await Firestore.firestore()
-                .collection("favorite-list")
-                .document(uuid)
-                .collection("list")
-                .getDocuments()
-
-            favoritePilgrimages = try querySnapshot.documents.map {
-                try $0.data(as: PilgrimageInformation.self)
-            }
+            favoritePilgrimages = try await favoriteRepository.fetchFavorites()
+        } catch let error as APIError {
+            alertMessage = error.localizedDescription
+            showAlert = true
         } catch {
-            if (error as NSError).domain == FirestoreErrorDomain {
-                alertMessage = APIError.fetchFavoritePilgrimagesError.localizedDescription
-            } else {
-                alertMessage = APIError.unknownError.localizedDescription
-            }
+            alertMessage = APIError.unknownError.localizedDescription
             showAlert = true
         }
     }
@@ -56,40 +47,22 @@ final class FavoriteViewModel {
         loadingItems.insert(pilgrimage.id)
         defer { loadingItems.remove(pilgrimage.id) }
 
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let collection = Firestore.firestore()
-            .collection("favorite-list")
-            .document(uuid)
-            .collection("list")
-        let documentRef = collection.document(pilgrimage.name)
-
         do {
             try await networkMonitor.monitorNetwork()
 
-            if (try await collection.getDocuments().documents
-                .first(where: { $0.documentID == pilgrimage.name })) != nil {
-                try await documentRef.delete()
+            let exists = try await favoriteRepository.isFavorited(pilgrimage.name)
+            if exists {
+                try await favoriteRepository.removeFavorite(pilgrimage)
+                favoritePilgrimages.removeAll { $0.id == pilgrimage.id }
             } else {
-                let data: [String: Any?] = [
-                    "code": pilgrimage.code,
-                    "name": pilgrimage.name,
-                    "description": pilgrimage.description,
-                    "latitude": pilgrimage.latitude,
-                    "longitude": pilgrimage.longitude,
-                    "address": pilgrimage.address,
-                    "image_url": pilgrimage.imageURL?.absoluteString,
-                    "copyright": pilgrimage.copyright,
-                    "search_candidate_list": pilgrimage.searchCandidateList
-                ]
-                try await documentRef.setData(data as [String: Any])
+                try await favoriteRepository.addFavorite(pilgrimage)
+                favoritePilgrimages.append(pilgrimage)
             }
-            await fetchFavorites()
+        } catch let error as APIError {
+            alertMessage = error.localizedDescription
+            showAlert = true
         } catch {
-            if (error as NSError).domain == FirestoreErrorDomain {
-                alertMessage = APIError.updateFavoritePilgrimagesError.localizedDescription
-            } else {
-                alertMessage = APIError.unknownError.localizedDescription
-            }
+            alertMessage = APIError.unknownError.localizedDescription
             showAlert = true
         }
     }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Card/PilgrimageCardViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Card/PilgrimageCardViewModel.swift
@@ -7,8 +7,7 @@
 
 import AppLogger
 import Dependencies
-import FirebaseFirestore
-import UIKit
+import Foundation
 
 @Observable
 final class PilgrimageCardViewModel {
@@ -16,6 +15,8 @@ final class PilgrimageCardViewModel {
     @Dependency(\.networkMonitor) var networkMonitor
     @ObservationIgnored
     @Dependency(\.routeActionClient) var routeActionClient
+    @ObservationIgnored
+    @Dependency(FavoriteRepository.self) var favoriteRepository
 
     var isLoading = false
     var favorited = false
@@ -42,15 +43,8 @@ final class PilgrimageCardViewModel {
     }
 
     func onAppear(pilgrimage: PilgrimageInformation) async {
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore()
-            .collection("favorite-list")
-            .document(uuid)
-            .collection("list")
-
         do {
-            let documents = try await querySnapshot.getDocuments().documents
-            favorited = documents.contains { $0.documentID == pilgrimage.name }
+            favorited = try await favoriteRepository.isFavorited(pilgrimage.name)
         } catch {
             #log(.error, "verifyFavorited failed: \(error.localizedDescription)")
         }
@@ -60,32 +54,18 @@ final class PilgrimageCardViewModel {
         isLoading = true
         defer { isLoading = false }
 
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore().collection("favorite-list").document(uuid).collection("list")
-        let documentReference = querySnapshot.document(pilgrimage.name)
-
         do {
             try await networkMonitor.monitorNetwork()
 
-            if (try await querySnapshot.getDocuments().documents.first(where: { $0.documentID == pilgrimage.name })) != nil {
-                try await documentReference.delete()
+            let exists = try await favoriteRepository.isFavorited(pilgrimage.name)
+            if exists {
+                try await favoriteRepository.removeFavorite(pilgrimage)
                 favorited = false
             } else {
-                let data: [String: Any?] = [
-                    "code": pilgrimage.code,
-                    "name": pilgrimage.name,
-                    "description": pilgrimage.description,
-                    "latitude": pilgrimage.latitude,
-                    "longitude": pilgrimage.longitude,
-                    "address": pilgrimage.address,
-                    "image_url": pilgrimage.imageURL?.absoluteString,
-                    "copyright": pilgrimage.copyright,
-                    "search_candidate_list": pilgrimage.searchCandidateList
-                ]
-                try await documentReference.setData(data as [String: Any])
+                try await favoriteRepository.addFavorite(pilgrimage)
                 favorited = true
             }
-        } catch let error as NSError where error.domain == FirestoreErrorDomain {
+        } catch is APIError {
             activeAlert = .updateFavoritePilgrimagesError
         } catch {
             activeAlert = .networkError

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
@@ -9,12 +9,14 @@ import AppLogger
 import CoreLocation
 import Dependencies
 import FirebaseFirestore
-import UIKit
+import Foundation
 
 @Observable
 final class PilgrimageDetailViewModel {
     @ObservationIgnored
     @Dependency(\.networkMonitor) var networkMonitor
+    @ObservationIgnored
+    @Dependency(FavoriteRepository.self) var favoriteRepository
 
     var isLoading = false
     var favorited = false
@@ -51,32 +53,18 @@ final class PilgrimageDetailViewModel {
         isLoading = true
         defer { isLoading = false }
 
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore().collection("favorite-list").document(uuid).collection("list")
-        let documentReference = querySnapshot.document(pilgrimage.name)
-
         do {
             try await networkMonitor.monitorNetwork()
 
-            if (try await querySnapshot.getDocuments().documents.first(where: { $0.documentID == pilgrimage.name })) != nil {
-                try await documentReference.delete()
+            let exists = try await favoriteRepository.isFavorited(pilgrimage.name)
+            if exists {
+                try await favoriteRepository.removeFavorite(pilgrimage)
                 favorited = false
             } else {
-                let data: [String: Any?] = [
-                    "code": pilgrimage.code,
-                    "name": pilgrimage.name,
-                    "description": pilgrimage.description,
-                    "latitude": pilgrimage.latitude,
-                    "longitude": pilgrimage.longitude,
-                    "address": pilgrimage.address,
-                    "image_url": pilgrimage.imageURL?.absoluteString,
-                    "copyright": pilgrimage.copyright,
-                    "search_candidate_list": pilgrimage.searchCandidateList
-                ]
-                try await documentReference.setData(data as [String: Any])
+                try await favoriteRepository.addFavorite(pilgrimage)
                 favorited = true
             }
-        } catch let error as NSError where error.domain == FirestoreErrorDomain {
+        } catch is APIError {
             activeAlert = .updateFavoritePilgrimagesError
         } catch {
             activeAlert = .networkError
@@ -122,15 +110,8 @@ final class PilgrimageDetailViewModel {
     }
 
     private func verifyFavorited(_ pilgrimage: PilgrimageInformation) async {
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore()
-            .collection("favorite-list")
-            .document(uuid)
-            .collection("list")
-
         do {
-            let documents = try await querySnapshot.getDocuments().documents
-            favorited = documents.contains { $0.documentID == pilgrimage.name }
+            favorited = try await favoriteRepository.isFavorited(pilgrimage.name)
         } catch {
             #log(.error, "verifyFavorited failed: \(error.localizedDescription)")
         }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListView.swift
@@ -35,6 +35,9 @@ struct PilgrimageListView: View {
                 searchText = viewModel.searchText
                 viewModel.onAppear(pilgrimages: pilgrimages)
             }
+            .task {
+                await viewModel.loadFavoriteStatuses()
+            }
             .alert(
                 viewModel.activeAlert?.title ?? "",
                 isPresented: $viewModel.isAlertPresented
@@ -98,9 +101,6 @@ struct PilgrimageListView: View {
                                 .padding(.vertical, 8)
                                 .padding(.horizontal, 16)
                                 .id(pilgrimage.id)
-                            }
-                            .onAppear {
-                                Task { await viewModel.verifyFavorited(pilgrimage: pilgrimage) }
                             }
                         }
                     }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListViewModel.swift
@@ -7,13 +7,14 @@
 
 import AppLogger
 import Dependencies
-import FirebaseFirestore
-import UIKit
+import Foundation
 
 @Observable
 final class PilgrimageListViewModel {
     @ObservationIgnored
     @Dependency(\.networkMonitor) var networkMonitor
+    @ObservationIgnored
+    @Dependency(FavoriteRepository.self) var favoriteRepository
 
     var pilgrimages: [PilgrimageInformation] = []
     var searchResults: [PilgrimageInformation] = []
@@ -21,7 +22,7 @@ final class PilgrimageListViewModel {
     var isLoading = false
     var scrollToIndex = 0
 
-    private var favoriteStatus: [Int: Bool] = [:]
+    private var favoritedIds: Set<Int> = []
     private var loadingItems: Set<Int> = []
 
     enum AlertType {
@@ -42,7 +43,7 @@ final class PilgrimageListViewModel {
     }
 
     func isFavorited(_ pilgrimage: PilgrimageInformation) -> Bool {
-        favoriteStatus[pilgrimage.id] ?? false
+        favoritedIds.contains(pilgrimage.id)
     }
 
     func isItemLoading(_ pilgrimage: PilgrimageInformation) -> Bool {
@@ -52,6 +53,15 @@ final class PilgrimageListViewModel {
     func onAppear(pilgrimages: [PilgrimageInformation]) {
         self.pilgrimages = pilgrimages
         searchPilgrimages(searchText)
+    }
+
+    func loadFavoriteStatuses() async {
+        do {
+            let favorites = try await favoriteRepository.fetchFavorites()
+            favoritedIds = Set(favorites.map(\.id))
+        } catch {
+            #log(.error, "loadFavoriteStatuses failed: \(error.localizedDescription)")
+        }
     }
 
     func searchPilgrimages(_ text: String) {
@@ -80,51 +90,21 @@ final class PilgrimageListViewModel {
         scrollToIndex = index
     }
 
-    func verifyFavorited(pilgrimage: PilgrimageInformation) async {
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore()
-            .collection("favorite-list")
-            .document(uuid)
-            .collection("list")
-
-        do {
-            let documents = try await querySnapshot.getDocuments().documents
-            favoriteStatus[pilgrimage.id] = documents.contains { $0.documentID == pilgrimage.name }
-        } catch {
-            #log(.error, "verifyFavorited failed: \(error.localizedDescription)")
-        }
-    }
-
     func toggleFavorite(pilgrimage: PilgrimageInformation) async {
         loadingItems.insert(pilgrimage.id)
         defer { loadingItems.remove(pilgrimage.id) }
 
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore().collection("favorite-list").document(uuid).collection("list")
-        let documentReference = querySnapshot.document(pilgrimage.name)
-
         do {
             try await networkMonitor.monitorNetwork()
 
-            if (try await querySnapshot.getDocuments().documents.first(where: { $0.documentID == pilgrimage.name })) != nil {
-                try await documentReference.delete()
-                favoriteStatus[pilgrimage.id] = false
+            if favoritedIds.contains(pilgrimage.id) {
+                try await favoriteRepository.removeFavorite(pilgrimage)
+                favoritedIds.remove(pilgrimage.id)
             } else {
-                let data: [String: Any?] = [
-                    "code": pilgrimage.code,
-                    "name": pilgrimage.name,
-                    "description": pilgrimage.description,
-                    "latitude": pilgrimage.latitude,
-                    "longitude": pilgrimage.longitude,
-                    "address": pilgrimage.address,
-                    "image_url": pilgrimage.imageURL?.absoluteString,
-                    "copyright": pilgrimage.copyright,
-                    "search_candidate_list": pilgrimage.searchCandidateList
-                ]
-                try await documentReference.setData(data as [String: Any])
-                favoriteStatus[pilgrimage.id] = true
+                try await favoriteRepository.addFavorite(pilgrimage)
+                favoritedIds.insert(pilgrimage.id)
             }
-        } catch let error as NSError where error.domain == FirestoreErrorDomain {
+        } catch is APIError {
             activeAlert = .updateFavoritePilgrimagesError
         } catch {
             activeAlert = .networkError

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Model/PilgrimageInformation.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Model/PilgrimageInformation.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import Foundation
 
-struct PilgrimageInformation: Hashable, Decodable {
+struct PilgrimageInformation: Hashable, Codable {
     let code: String
     let name: String
     let description: String


### PR DESCRIPTION
## Summary
- `FavoriteRepository`（Domain層）+ `FavoriteRepository+Live`（Data層）を作成し、お気に入り操作を Repository パターンに統一
- `FavoriteRemoteDataStore`（Firestore CRUD）、`FavoriteLocalDataStore`（actor ベースのインメモリキャッシュ）を作成
- 4つの ViewModel（Favorite, List, Detail, Card）から Firestore 直接アクセスを排除し、Repository 経由に統一
- `PilgrimageInformation` を `Codable` に変更し `setData(from:)` を利用可能にした
- `PilgrimageListViewModel` のお気に入り状態管理を `Set<Int>` に簡素化し、並行辞書書き込みによるクラッシュを修正

## Architecture
```
Feature (ViewModel)
  └── @Dependency(FavoriteRepository.self)     ← Domain/RepositoryProtocol/

FavoriteRepository+Live (Data/Repository/)
  ├── @Dependency(FavoriteRemoteDataStore.self) ← Data/DataStore/Remote/
  └── @Dependency(FavoriteLocalDataStore.self)  ← Data/DataStore/Local/
```

## Cache strategy
- `fetchFavorites` → 常に Remote から取得 + キャッシュ更新
- `isFavorited` → キャッシュがあればキャッシュ参照、なければ Remote 取得 + キャッシュ
- `addFavorite` / `removeFavorite` → Remote 書き込み成功後にキャッシュも同期更新

## Test plan
- [ ] お気に入り一覧の取得・表示が正しく動作すること
- [ ] お気に入りの追加・削除が正しく動作すること
- [ ] 聖地一覧画面でお気に入り状態が正しく表示されること
- [ ] 詳細画面・カード画面でお気に入りトグルが正しく動作すること
- [ ] 各 ViewModel から `import FirebaseFirestore` が不要になっていること（Detail は checkIn で使用のため残存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)