### PR TITLE
CheckInRepository + CheckInUseCase を作成

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		E72EA33D2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */; };
 		E72EA33F2F55E7D2007BFC81 /* FavoriteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */; };
 		E72EA3412F55E7DF007BFC81 /* FavoriteRepository+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */; };
+		E72EA3442F5703B1007BFC81 /* CheckInRemoteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3432F5703B1007BFC81 /* CheckInRemoteDataStore.swift */; };
+		E72EA3462F5703C7007BFC81 /* CheckInRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3452F5703C7007BFC81 /* CheckInRepository.swift */; };
+		E72EA3482F57042C007BFC81 /* CheckInRepository+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3472F57042C007BFC81 /* CheckInRepository+Live.swift */; };
+		E72EA34A2F570441007BFC81 /* CheckInUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3492F570441007BFC81 /* CheckInUseCase.swift */; };
+		E72EA34C2F570852007BFC81 /* CheckInLocalDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA34B2F570852007BFC81 /* CheckInLocalDataStore.swift */; };
 		E73E09122965C21E00A1204E /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73E09112965C21E00A1204E /* MainView.swift */; };
 		E73E091B2965C77E00A1204E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E73E091A2965C77E00A1204E /* Colors.xcassets */; };
 		E73E092E2965D18700A1204E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E73E09302965D18700A1204E /* Localizable.strings */; };
@@ -104,6 +109,11 @@
 		E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRemoteDataStore.swift; sourceTree = "<group>"; };
 		E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRepository.swift; sourceTree = "<group>"; };
 		E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FavoriteRepository+Live.swift"; sourceTree = "<group>"; };
+		E72EA3432F5703B1007BFC81 /* CheckInRemoteDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInRemoteDataStore.swift; sourceTree = "<group>"; };
+		E72EA3452F5703C7007BFC81 /* CheckInRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInRepository.swift; sourceTree = "<group>"; };
+		E72EA3472F57042C007BFC81 /* CheckInRepository+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CheckInRepository+Live.swift"; sourceTree = "<group>"; };
+		E72EA3492F570441007BFC81 /* CheckInUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInUseCase.swift; sourceTree = "<group>"; };
+		E72EA34B2F570852007BFC81 /* CheckInLocalDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInLocalDataStore.swift; sourceTree = "<group>"; };
 		E73E09112965C21E00A1204E /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		E73E091A2965C77E00A1204E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		E73E092F2965D18700A1204E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -244,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */,
+				E72EA3472F57042C007BFC81 /* CheckInRepository+Live.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -261,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */,
+				E72EA3452F5703C7007BFC81 /* CheckInRepository.swift */,
 			);
 			path = RepositoryProtocol;
 			sourceTree = "<group>";
@@ -269,6 +281,7 @@
 			isa = PBXGroup;
 			children = (
 				E72EA3352F55D530007BFC81 /* RepositoryProtocol */,
+				E72EA3422F57037A007BFC81 /* UseCase */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -286,6 +299,7 @@
 			isa = PBXGroup;
 			children = (
 				E72EA33A2F55E7A3007BFC81 /* FavoriteLocalDataStore.swift */,
+				E72EA34B2F570852007BFC81 /* CheckInLocalDataStore.swift */,
 			);
 			path = Local;
 			sourceTree = "<group>";
@@ -294,8 +308,17 @@
 			isa = PBXGroup;
 			children = (
 				E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */,
+				E72EA3432F5703B1007BFC81 /* CheckInRemoteDataStore.swift */,
 			);
 			path = Remote;
+			sourceTree = "<group>";
+		};
+		E72EA3422F57037A007BFC81 /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				E72EA3492F570441007BFC81 /* CheckInUseCase.swift */,
+			);
+			path = UseCase;
 			sourceTree = "<group>";
 		};
 		E73E090F2965C1FC00A1204E /* View */ = {
@@ -799,6 +822,7 @@
 				E72EA33D2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift in Sources */,
 				E7FDAA112AE177CB0056AA5B /* UIColorExtension.swift in Sources */,
 				E7B931432F46053A00B94C75 /* IconLicenseView.swift in Sources */,
+				E72EA3482F57042C007BFC81 /* CheckInRepository+Live.swift in Sources */,
 				E795AAC82F50558E0062C9CE /* PilgrimageCardViewModel.swift in Sources */,
 				E73E09122965C21E00A1204E /* MainView.swift in Sources */,
 				E755E4262F4DD85800EF8E2F /* CheckInViewModel.swift in Sources */,
@@ -823,13 +847,16 @@
 				E795AAB72F4DEA460062C9CE /* FavoriteView.swift in Sources */,
 				E7EA0F572BB5C49500EC8A93 /* SafariEffect.swift in Sources */,
 				E755E42A2F4DD95C00EF8E2F /* CheckInContentView.swift in Sources */,
+				E72EA34A2F570441007BFC81 /* CheckInUseCase.swift in Sources */,
 				E78276092BAC796000AD16CC /* NetworkMonitor.swift in Sources */,
 				E795AAB52F4DEA390062C9CE /* FavoriteViewModel.swift in Sources */,
+				E72EA3462F5703C7007BFC81 /* CheckInRepository.swift in Sources */,
 				E7B931482F4749AB00B94C75 /* MenuView.swift in Sources */,
 				E7FDAA172AE230310056AA5B /* UINavigationControllerExtension.swift in Sources */,
 				E72EA33F2F55E7D2007BFC81 /* FavoriteRepository.swift in Sources */,
 				E795AAD02F5055BE0062C9CE /* PilgrimageListContentView.swift in Sources */,
 				E7C11D40295AF19A0051A1B9 /* R.generated.swift in Sources */,
+				E72EA34C2F570852007BFC81 /* CheckInLocalDataStore.swift in Sources */,
 				E795AABC2F4F37830062C9CE /* LaunchViewModel.swift in Sources */,
 				E795AAD62F5055EC0062C9CE /* PilgrimageView.swift in Sources */,
 				E795AACA2F50559C0062C9CE /* PilgrimageCardView.swift in Sources */,
@@ -841,6 +868,7 @@
 				E72EA3412F55E7DF007BFC81 /* FavoriteRepository+Live.swift in Sources */,
 				E7FDAA002ADFDDFB0056AA5B /* PilgrimageInformation.swift in Sources */,
 				E76BF1652BD16FE700A1CB97 /* NativeAdvanceView.swift in Sources */,
+				E72EA3442F5703B1007BFC81 /* CheckInRemoteDataStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Local/CheckInLocalDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Local/CheckInLocalDataStore.swift
@@ -1,0 +1,35 @@
+//
+//  CheckInLocalDataStore.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct CheckInLocalDataStore {
+    var getAll: () async -> [PilgrimageInformation]?
+    var setAll: (_ pilgrimages: [PilgrimageInformation]) async -> Void
+    var add: (_ pilgrimage: PilgrimageInformation) async -> Void
+}
+
+extension CheckInLocalDataStore: DependencyKey {
+    static let liveValue: Self = {
+        let storage = CheckInLocalStorage()
+        return .init(
+            getAll: { await storage.getAll() },
+            setAll: { await storage.setAll($0) },
+            add: { await storage.add($0) }
+        )
+    }()
+}
+
+private actor CheckInLocalStorage {
+    private var pilgrimages: [PilgrimageInformation]?
+
+    func getAll() -> [PilgrimageInformation]? { pilgrimages }
+    func setAll(_ items: [PilgrimageInformation]) { pilgrimages = items }
+    func add(_ item: PilgrimageInformation) { pilgrimages?.append(item) }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/CheckInRemoteDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/CheckInRemoteDataStore.swift
@@ -1,0 +1,45 @@
+//
+//  CheckInRemoteDataStore.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+import FirebaseFirestore
+import UIKit
+
+@DependencyClient
+struct CheckInRemoteDataStore {
+    var fetchAll: () async throws -> [PilgrimageInformation]
+    var exists: (_ name: String) async throws -> Bool
+    var add: (_ pilgrimage: PilgrimageInformation) async throws -> Void
+}
+
+extension CheckInRemoteDataStore: DependencyKey {
+    static let liveValue: Self = {
+        return .init(
+            fetchAll: {
+                let snapshot = try await collectionRef().getDocuments()
+                return try snapshot.documents.map { try $0.data(as: PilgrimageInformation.self) }
+            },
+            exists: { name in
+                let snapshot = try await collectionRef().getDocuments()
+                return snapshot.documents.contains { $0.documentID == name }
+            },
+            add: { pilgrimage in
+                let ref = await collectionRef().document(pilgrimage.name)
+                try ref.setData(from: pilgrimage)
+            }
+        )
+    }()
+
+    private static func collectionRef() async -> CollectionReference {
+        let uuid = await UIDevice.current.identifierForVendor!.uuidString
+        return Firestore.firestore()
+            .collection("checked-in-list")
+            .document(uuid)
+            .collection("list")
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/CheckInRepository+Live.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/CheckInRepository+Live.swift
@@ -1,0 +1,55 @@
+//
+//  CheckInRepository+Live.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import FirebaseFirestore
+
+extension CheckInRepository: DependencyKey {
+    static let liveValue: Self = {
+        @Dependency(CheckInRemoteDataStore.self) var remoteDataStore
+        @Dependency(CheckInLocalDataStore.self) var localDataStore
+
+        return .init(
+            fetchCheckedInPilgrimages: {
+                do {
+                    let result = try await remoteDataStore.fetchAll()
+                    await localDataStore.setAll(result)
+                    return result
+                } catch {
+                    throw mapError(error, to: .fetchCheckedInError)
+                }
+            },
+            isCheckedIn: { name in
+                if let cached = await localDataStore.getAll() {
+                    return cached.contains { $0.name == name }
+                }
+                do {
+                    let result = try await remoteDataStore.fetchAll()
+                    await localDataStore.setAll(result)
+                    return result.contains { $0.name == name }
+                } catch {
+                    throw mapError(error, to: .fetchCheckedInError)
+                }
+            },
+            addCheckIn: { pilgrimage in
+                do {
+                    try await remoteDataStore.add(pilgrimage)
+                    await localDataStore.add(pilgrimage)
+                } catch {
+                    throw mapError(error, to: .updateCheckedInError)
+                }
+            }
+        )
+    }()
+
+    private static func mapError(_ error: Error, to apiError: APIError) -> APIError {
+        if (error as NSError).domain == FirestoreErrorDomain {
+            return apiError
+        }
+        return .unknownError
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/CheckInRepository.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/CheckInRepository.swift
@@ -1,0 +1,16 @@
+//
+//  CheckInRepository.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct CheckInRepository {
+    var fetchCheckedInPilgrimages: () async throws -> [PilgrimageInformation]
+    var isCheckedIn: (_ name: String) async throws -> Bool
+    var addCheckIn: (_ pilgrimage: PilgrimageInformation) async throws -> Void
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/UseCase/CheckInUseCase.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/UseCase/CheckInUseCase.swift
@@ -1,0 +1,46 @@
+//
+//  CheckInUseCase.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import CoreLocation
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct CheckInUseCase {
+    var execute: (_ pilgrimage: PilgrimageInformation, _ userCoordinate: CLLocationCoordinate2D) async throws -> Bool
+}
+
+extension CheckInUseCase: DependencyKey {
+    static let liveValue: Self = {
+        @Dependency(CheckInRepository.self) var checkInRepository
+
+        return .init(
+            execute: { pilgrimage, userCoordinate in
+                let distanceThreshold = 200.0
+                let userLocation = CLLocation(latitude: userCoordinate.latitude, longitude: userCoordinate.longitude)
+                let pilgrimageLocation = CLLocation(
+                    latitude: pilgrimage.coordinate.latitude,
+                    longitude: pilgrimage.coordinate.longitude
+                )
+                guard userLocation.distance(from: pilgrimageLocation) < distanceThreshold else {
+                    throw CheckInError.notNearby
+                }
+
+                guard try await !checkInRepository.isCheckedIn(pilgrimage.name) else {
+                    return false
+                }
+
+                try await checkInRepository.addCheckIn(pilgrimage)
+                return true
+            }
+        )
+    }()
+}
+
+enum CheckInError: Error {
+    case notNearby
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/CheckIn/CheckInViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/CheckIn/CheckInViewModel.swift
@@ -5,12 +5,14 @@
 //  Created by k_kudo on 2026/02/24.
 //
 
-import FirebaseFirestore
+import Dependencies
 import Foundation
-import UIKit
 
 @Observable
 final class CheckInViewModel {
+    @ObservationIgnored
+    @Dependency(CheckInRepository.self) var checkInRepository
+
     var checkedInPilgrimages: [PilgrimageInformation] = []
     var isLoading = false
     var alertMessage: String?
@@ -21,22 +23,12 @@ final class CheckInViewModel {
         defer { isLoading = false }
 
         do {
-            let uuid = await UIDevice.current.identifierForVendor!.uuidString
-            let querySnapshot = try await Firestore.firestore()
-                .collection("checked-in-list")
-                .document(uuid)
-                .collection("list")
-                .getDocuments()
-
-            checkedInPilgrimages = try querySnapshot.documents.map {
-                try $0.data(as: PilgrimageInformation.self)
-            }
+            checkedInPilgrimages = try await checkInRepository.fetchCheckedInPilgrimages()
+        } catch is APIError {
+            alertMessage = APIError.fetchCheckedInError.localizedDescription
+            showAlert = true
         } catch {
-            if (error as NSError).domain == FirestoreErrorDomain {
-                alertMessage = APIError.fetchCheckedInError.localizedDescription
-            } else {
-                alertMessage = APIError.unknownError.localizedDescription
-            }
+            alertMessage = APIError.unknownError.localizedDescription
             showAlert = true
         }
     }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
@@ -8,7 +8,6 @@
 import AppLogger
 import CoreLocation
 import Dependencies
-import FirebaseFirestore
 import Foundation
 
 @Observable
@@ -17,6 +16,10 @@ final class PilgrimageDetailViewModel {
     @Dependency(\.networkMonitor) var networkMonitor
     @ObservationIgnored
     @Dependency(FavoriteRepository.self) var favoriteRepository
+    @ObservationIgnored
+    @Dependency(CheckInRepository.self) var checkInRepository
+    @ObservationIgnored
+    @Dependency(CheckInUseCase.self) var checkInUseCase
 
     var isLoading = false
     var favorited = false
@@ -72,37 +75,17 @@ final class PilgrimageDetailViewModel {
     }
 
     func checkIn(pilgrimage: PilgrimageInformation, userCoordinate: CLLocationCoordinate2D) async {
-        guard isNearbyPilgrimage(userCoordinate: userCoordinate, pilgrimageCoordinate: pilgrimage.coordinate) else {
-            activeAlert = .notNearbyError
-            return
-        }
-
         isLoading = true
         defer { isLoading = false }
 
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore().collection("checked-in-list").document(uuid).collection("list")
-        let documentReference = querySnapshot.document(pilgrimage.name)
-
         do {
-            if (try await querySnapshot.getDocuments().documents.first(where: { $0.documentID == pilgrimage.name })) != nil {
-                hasCheckedIn = false
-            } else {
-                let data: [String: Any?] = [
-                    "code": pilgrimage.code,
-                    "name": pilgrimage.name,
-                    "description": pilgrimage.description,
-                    "latitude": pilgrimage.latitude,
-                    "longitude": pilgrimage.longitude,
-                    "address": pilgrimage.address,
-                    "image_url": pilgrimage.imageURL?.absoluteString,
-                    "copyright": pilgrimage.copyright,
-                    "search_candidate_list": pilgrimage.searchCandidateList
-                ]
-                try await documentReference.setData(data as [String: Any])
+            let isNewCheckIn = try await checkInUseCase.execute(pilgrimage, userCoordinate)
+            if isNewCheckIn {
                 hasCheckedIn = true
             }
-        } catch let error as NSError where error.domain == FirestoreErrorDomain {
+        } catch is CheckInError {
+            activeAlert = .notNearbyError
+        } catch is APIError {
             activeAlert = .updateCheckedInError
         } catch {
             activeAlert = .networkError
@@ -118,24 +101,10 @@ final class PilgrimageDetailViewModel {
     }
 
     private func verifyCheckedIn(_ pilgrimage: PilgrimageInformation) async {
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
-        let querySnapshot = Firestore.firestore()
-            .collection("checked-in-list")
-            .document(uuid)
-            .collection("list")
-
         do {
-            let documents = try await querySnapshot.getDocuments().documents
-            hasCheckedIn = documents.contains { $0.documentID == pilgrimage.name }
+            hasCheckedIn = try await checkInRepository.isCheckedIn(pilgrimage.name)
         } catch {
             #log(.error, "verifyCheckedIn failed: \(error.localizedDescription)")
         }
-    }
-
-    private func isNearbyPilgrimage(userCoordinate: CLLocationCoordinate2D, pilgrimageCoordinate: CLLocationCoordinate2D) -> Bool {
-        let distanceThreshold = 200.0
-        let userLocation = CLLocation(latitude: userCoordinate.latitude, longitude: userCoordinate.longitude)
-        let pilgrimageLocation = CLLocation(latitude: pilgrimageCoordinate.latitude, longitude: pilgrimageCoordinate.longitude)
-        return userLocation.distance(from: pilgrimageLocation) < distanceThreshold
     }
 }


### PR DESCRIPTION
## Summary
- `CheckInRepository`（Domain層）+ `CheckInRepository+Live`（Data層）を作成し、チェックイン操作を Repository パターンに統一
- `CheckInRemoteDataStore`（Firestore CRUD）、`CheckInLocalDataStore`（actor ベースのインメモリキャッシュ）を作成
- `CheckInUseCase`（位置検証 + 重複チェック + 書き込み）を作成し、ビジネスロジックを Domain 層に移動
- `CheckInViewModel` と `PilgrimageDetailViewModel` から Firestore 直接アクセスを排除
- `PilgrimageDetailViewModel` の checkIn バグを修正（既にチェックイン済みの場合 `hasCheckedIn = false` になっていた）

## Architecture
```
PilgrimageDetailViewModel (Feature/)
  ├── @Dependency(CheckInUseCase.self)         ← Domain/UseCase/
  ├── @Dependency(CheckInRepository.self)      ← Domain/RepositoryProtocol/
  └── @Dependency(FavoriteRepository.self)     ← Domain/RepositoryProtocol/

CheckInUseCase (Domain/UseCase/)
  └── @Dependency(CheckInRepository.self)      ← Domain/RepositoryProtocol/

CheckInRepository+Live (Data/Repository/)
  ├── @Dependency(CheckInRemoteDataStore.self) ← Data/DataStore/Remote/
  └── @Dependency(CheckInLocalDataStore.self)  ← Data/DataStore/Local/
```

## Cache strategy
- `fetchCheckedInPilgrimages` → Remote 取得 + キャッシュ更新
- `isCheckedIn` → キャッシュあり → 即判定 / なし → Remote 取得 + キャッシュ
- `addCheckIn` → Remote 書き込み + キャッシュに追加

## Bug fix
- `PilgrimageDetailViewModel.checkIn()`: 既にチェックイン済みの聖地で再度チェックインボタンを押すと `hasCheckedIn = false` になるバグを修正

## Test plan
- [ ] チェックイン済み一覧の取得・表示が正しく動作すること
- [ ] 近くの聖地でチェックインが正しく動作すること
- [ ] 遠くの聖地でチェックイン時にエラーアラートが表示されること
- [ ] 既にチェックイン済みの聖地で再チェックインしても `hasCheckedIn` が `false` にならないこと
- [ ] `PilgrimageDetailViewModel` から `import FirebaseFirestore` が削除されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)