### PR TITLE
PilgrimageRepository + AppConfigRepository を作成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,20 +89,24 @@ Domain/           # Domain層（ビジネスエンティティ・ルール）
 └── RepositoryProtocol/            # @DependencyClient struct（インターフェース）
     ├── PilgrimageRepository.swift
     ├── CheckInRepository.swift
-    └── FavoriteRepository.swift
+    ├── FavoriteRepository.swift
+    └── AppConfigRepository.swift
 
 Data/             # Data層（Repository実装・DataStore）
 ├── Repository/                   # extension + liveValue（Firestore実装）
 │   ├── PilgrimageRepository+Live.swift
 │   ├── CheckInRepository+Live.swift
-│   └── FavoriteRepository+Live.swift
+│   ├── FavoriteRepository+Live.swift
+│   └── AppConfigRepository+Live.swift
 └── DataStore/
     ├── Remote/
     │   ├── PilgrimageRemoteDataStore.swift
     │   ├── CheckInRemoteDataStore.swift
-    │   └── FavoriteRemoteDataStore.swift
+    │   ├── FavoriteRemoteDataStore.swift
+    │   └── AppConfigRemoteDataStore.swift
     └── Local/                    # ローカルキャッシュ（インメモリ → SwiftData予定）
-        └── FavoriteLocalDataStore.swift
+        ├── FavoriteLocalDataStore.swift
+        └── CheckInLocalDataStore.swift
 
 Utility/          # 既存のまま（LocationManager, Theme等）
 ```
@@ -145,5 +149,5 @@ Swift Package Manager を使用。TCA 廃止後は `Package.swift` に直接 `sw
 
 ## Firebase キャッシュ方針
 
-- Phase 1（実装済み）: インメモリキャッシュ（`FavoriteLocalDataStore` — actor ベース）
-- Phase 2（予定）: SwiftData 導入、PilgrimageRepository 作成、お気に入りを ID のみ保持に変更
+- Phase 1（実装済み）: インメモリキャッシュ（`FavoriteLocalDataStore` / `CheckInLocalDataStore` — actor ベース）
+- Phase 2（予定）: SwiftData 導入、聖地データのローカルキャッシュ + TTL、お気に入りを完全ローカル化（ID のみ保持）

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 		E72EA3482F57042C007BFC81 /* CheckInRepository+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3472F57042C007BFC81 /* CheckInRepository+Live.swift */; };
 		E72EA34A2F570441007BFC81 /* CheckInUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3492F570441007BFC81 /* CheckInUseCase.swift */; };
 		E72EA34C2F570852007BFC81 /* CheckInLocalDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA34B2F570852007BFC81 /* CheckInLocalDataStore.swift */; };
+		E72EA34E2F57166E007BFC81 /* PilgrimageRemoteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA34D2F57166E007BFC81 /* PilgrimageRemoteDataStore.swift */; };
+		E72EA3502F571683007BFC81 /* PilgrimageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA34F2F571683007BFC81 /* PilgrimageRepository.swift */; };
+		E72EA3522F571698007BFC81 /* PilgrimageRepository+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3512F571698007BFC81 /* PilgrimageRepository+Live.swift */; };
+		E72EA3542F5716B2007BFC81 /* AppConfigRemoteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3532F5716B2007BFC81 /* AppConfigRemoteDataStore.swift */; };
+		E72EA3562F5716C2007BFC81 /* AppConfigRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3552F5716C2007BFC81 /* AppConfigRepository.swift */; };
+		E72EA3582F5716D0007BFC81 /* AppConfigRepository+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72EA3572F5716D0007BFC81 /* AppConfigRepository+Live.swift */; };
 		E73E09122965C21E00A1204E /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73E09112965C21E00A1204E /* MainView.swift */; };
 		E73E091B2965C77E00A1204E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E73E091A2965C77E00A1204E /* Colors.xcassets */; };
 		E73E092E2965D18700A1204E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E73E09302965D18700A1204E /* Localizable.strings */; };
@@ -114,6 +120,12 @@
 		E72EA3472F57042C007BFC81 /* CheckInRepository+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CheckInRepository+Live.swift"; sourceTree = "<group>"; };
 		E72EA3492F570441007BFC81 /* CheckInUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInUseCase.swift; sourceTree = "<group>"; };
 		E72EA34B2F570852007BFC81 /* CheckInLocalDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInLocalDataStore.swift; sourceTree = "<group>"; };
+		E72EA34D2F57166E007BFC81 /* PilgrimageRemoteDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimageRemoteDataStore.swift; sourceTree = "<group>"; };
+		E72EA34F2F571683007BFC81 /* PilgrimageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimageRepository.swift; sourceTree = "<group>"; };
+		E72EA3512F571698007BFC81 /* PilgrimageRepository+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PilgrimageRepository+Live.swift"; sourceTree = "<group>"; };
+		E72EA3532F5716B2007BFC81 /* AppConfigRemoteDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigRemoteDataStore.swift; sourceTree = "<group>"; };
+		E72EA3552F5716C2007BFC81 /* AppConfigRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigRepository.swift; sourceTree = "<group>"; };
+		E72EA3572F5716D0007BFC81 /* AppConfigRepository+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppConfigRepository+Live.swift"; sourceTree = "<group>"; };
 		E73E09112965C21E00A1204E /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		E73E091A2965C77E00A1204E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		E73E092F2965D18700A1204E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -255,6 +267,8 @@
 			children = (
 				E72EA3402F55E7DF007BFC81 /* FavoriteRepository+Live.swift */,
 				E72EA3472F57042C007BFC81 /* CheckInRepository+Live.swift */,
+				E72EA3512F571698007BFC81 /* PilgrimageRepository+Live.swift */,
+				E72EA3572F5716D0007BFC81 /* AppConfigRepository+Live.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -273,6 +287,8 @@
 			children = (
 				E72EA33E2F55E7D2007BFC81 /* FavoriteRepository.swift */,
 				E72EA3452F5703C7007BFC81 /* CheckInRepository.swift */,
+				E72EA34F2F571683007BFC81 /* PilgrimageRepository.swift */,
+				E72EA3552F5716C2007BFC81 /* AppConfigRepository.swift */,
 			);
 			path = RepositoryProtocol;
 			sourceTree = "<group>";
@@ -309,6 +325,8 @@
 			children = (
 				E72EA33C2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift */,
 				E72EA3432F5703B1007BFC81 /* CheckInRemoteDataStore.swift */,
+				E72EA34D2F57166E007BFC81 /* PilgrimageRemoteDataStore.swift */,
+				E72EA3532F5716B2007BFC81 /* AppConfigRemoteDataStore.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -821,21 +839,26 @@
 				E795AACE2F5055B40062C9CE /* PilgrimageListView.swift in Sources */,
 				E72EA33D2F55E7B4007BFC81 /* FavoriteRemoteDataStore.swift in Sources */,
 				E7FDAA112AE177CB0056AA5B /* UIColorExtension.swift in Sources */,
+				E72EA34E2F57166E007BFC81 /* PilgrimageRemoteDataStore.swift in Sources */,
 				E7B931432F46053A00B94C75 /* IconLicenseView.swift in Sources */,
 				E72EA3482F57042C007BFC81 /* CheckInRepository+Live.swift in Sources */,
 				E795AAC82F50558E0062C9CE /* PilgrimageCardViewModel.swift in Sources */,
 				E73E09122965C21E00A1204E /* MainView.swift in Sources */,
 				E755E4262F4DD85800EF8E2F /* CheckInViewModel.swift in Sources */,
+				E72EA3522F571698007BFC81 /* PilgrimageRepository+Live.swift in Sources */,
 				E795AABE2F4F37B50062C9CE /* LaunchView.swift in Sources */,
+				E72EA3562F5716C2007BFC81 /* AppConfigRepository.swift in Sources */,
 				E795AAC42F50556B0062C9CE /* PilgrimageDetailViewModel.swift in Sources */,
 				E74934462959F20E0045AE39 /* nogizaka_pilgrimageApp.swift in Sources */,
 				E75907A92AD58F5E009327A8 /* ThemeEnvironmentKey.swift in Sources */,
+				E72EA3542F5716B2007BFC81 /* AppConfigRemoteDataStore.swift in Sources */,
 				E76BF15E2BD1630C00A1CB97 /* NativeAdvanceViewController.swift in Sources */,
 				E7A1271A2B8F854D004D877A /* APIError.swift in Sources */,
 				E79D8C982E438635006170C3 /* PilgrimageAnnotation.swift in Sources */,
 				E79045B22B0E088100F0936B /* LocationManager.swift in Sources */,
 				E7FDAA042ADFEB7E0056AA5B /* PilgrimageMapConstant.swift in Sources */,
 				E755E4282F4DD86900EF8E2F /* CheckInView.swift in Sources */,
+				E72EA3502F571683007BFC81 /* PilgrimageRepository.swift in Sources */,
 				E795AACC2F5055AA0062C9CE /* PilgrimageListViewModel.swift in Sources */,
 				E71A82792BE200B700C16FEE /* BuildClient.swift in Sources */,
 				E79D8C922E43859C006170C3 /* ClusterMapView.swift in Sources */,
@@ -853,6 +876,7 @@
 				E72EA3462F5703C7007BFC81 /* CheckInRepository.swift in Sources */,
 				E7B931482F4749AB00B94C75 /* MenuView.swift in Sources */,
 				E7FDAA172AE230310056AA5B /* UINavigationControllerExtension.swift in Sources */,
+				E72EA3582F5716D0007BFC81 /* AppConfigRepository+Live.swift in Sources */,
 				E72EA33F2F55E7D2007BFC81 /* FavoriteRepository.swift in Sources */,
 				E795AAD02F5055BE0062C9CE /* PilgrimageListContentView.swift in Sources */,
 				E7C11D40295AF19A0051A1B9 /* R.generated.swift in Sources */,

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/AppConfigRemoteDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/AppConfigRemoteDataStore.swift
@@ -1,0 +1,29 @@
+//
+//  AppConfigRemoteDataStore.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+import FirebaseFirestore
+
+@DependencyClient
+struct AppConfigRemoteDataStore {
+    var fetchUpdateInfo: () async throws -> AppUpdateInformation
+}
+
+extension AppConfigRemoteDataStore: DependencyKey {
+    static let liveValue: Self = {
+        return .init(
+            fetchUpdateInfo: {
+                return try await Firestore.firestore()
+                    .collection("configure")
+                    .document("update")
+                    .getDocument()
+                    .data(as: AppUpdateInformation.self)
+            }
+        )
+    }()
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/PilgrimageRemoteDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/PilgrimageRemoteDataStore.swift
@@ -1,0 +1,28 @@
+//
+//  PilgrimageRemoteDataStore.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+import FirebaseFirestore
+
+@DependencyClient
+struct PilgrimageRemoteDataStore {
+    var fetchAll: () async throws -> [PilgrimageInformation]
+}
+
+extension PilgrimageRemoteDataStore: DependencyKey {
+    static let liveValue: Self = {
+        return .init(
+            fetchAll: {
+                let snapshot = try await Firestore.firestore()
+                    .collection("pilgrimage-list")
+                    .getDocuments()
+                return try snapshot.documents.map { try $0.data(as: PilgrimageInformation.self) }
+            }
+        )
+    }()
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/AppConfigRepository+Live.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/AppConfigRepository+Live.swift
@@ -1,0 +1,28 @@
+//
+//  AppConfigRepository+Live.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import FirebaseFirestore
+
+extension AppConfigRepository: DependencyKey {
+    static let liveValue: Self = {
+        @Dependency(AppConfigRemoteDataStore.self) var remoteDataStore
+
+        return .init(
+            fetchUpdateInfo: {
+                do {
+                    return try await remoteDataStore.fetchUpdateInfo()
+                } catch {
+                    if (error as NSError).domain == FirestoreErrorDomain {
+                        throw APIError.networkError
+                    }
+                    throw APIError.unknownError
+                }
+            }
+        )
+    }()
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/PilgrimageRepository+Live.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Repository/PilgrimageRepository+Live.swift
@@ -1,0 +1,32 @@
+//
+//  PilgrimageRepository+Live.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import FirebaseFirestore
+
+extension PilgrimageRepository: DependencyKey {
+    static let liveValue: Self = {
+        @Dependency(PilgrimageRemoteDataStore.self) var remoteDataStore
+
+        return .init(
+            fetchAllPilgrimages: {
+                do {
+                    return try await remoteDataStore.fetchAll()
+                } catch {
+                    throw mapError(error, to: .fetchPilgrimagesError)
+                }
+            }
+        )
+    }()
+
+    private static func mapError(_ error: Error, to apiError: APIError) -> APIError {
+        if (error as NSError).domain == FirestoreErrorDomain {
+            return apiError
+        }
+        return .unknownError
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/AppConfigRepository.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/AppConfigRepository.swift
@@ -1,0 +1,14 @@
+//
+//  AppConfigRepository.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct AppConfigRepository {
+    var fetchUpdateInfo: () async throws -> AppUpdateInformation
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/PilgrimageRepository.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/RepositoryProtocol/PilgrimageRepository.swift
@@ -1,0 +1,14 @@
+//
+//  PilgrimageRepository.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/03.
+//
+
+import Dependencies
+import DependenciesMacros
+
+@DependencyClient
+struct PilgrimageRepository {
+    var fetchAllPilgrimages: () async throws -> [PilgrimageInformation]
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Dependencies
-import FirebaseFirestore
+import Foundation
 
 @Observable
 final class LaunchViewModel {
@@ -14,6 +14,10 @@ final class LaunchViewModel {
     @Dependency(\.buildClient) var buildClient
     @ObservationIgnored
     @Dependency(\.networkMonitor) var networkMonitor
+    @ObservationIgnored
+    @Dependency(PilgrimageRepository.self) var pilgrimageRepository
+    @ObservationIgnored
+    @Dependency(AppConfigRepository.self) var appConfigRepository
 
     var pilgrimages: [PilgrimageInformation] = []
     var isLoading = true
@@ -53,20 +57,12 @@ final class LaunchViewModel {
 
         do {
             try await networkMonitor.monitorNetwork()
-
-            let querySnapshot = try await Firestore.firestore()
-                .collection("pilgrimage-list")
-                .getDocuments()
-
-            pilgrimages = try querySnapshot.documents
-                .map { try $0.data(as: PilgrimageInformation.self) }
+            pilgrimages = try await pilgrimageRepository.fetchAllPilgrimages()
                 .sorted { $0.code < $1.code }
+        } catch is APIError {
+            activeAlert = .fetchError
         } catch {
-            if (error as NSError).domain == FirestoreErrorDomain {
-                activeAlert = .fetchError
-            } else {
-                activeAlert = .networkError
-            }
+            activeAlert = .networkError
         }
     }
 
@@ -77,12 +73,7 @@ final class LaunchViewModel {
     private func checkForUpdate() async {
         do {
             try await networkMonitor.monitorNetwork()
-
-            let appUpdateInfo = try await Firestore.firestore()
-                .collection("configure")
-                .document("update")
-                .getDocument()
-                .data(as: AppUpdateInformation.self)
+            let appUpdateInfo = try await appConfigRepository.fetchUpdateInfo()
 
             if appUpdateInfo.targetVersion.compare(buildClient.appVersion()) == .orderedDescending {
                 pendingUpdate = appUpdateInfo


### PR DESCRIPTION
## Summary
- `PilgrimageRepository`（Domain層）+ `PilgrimageRepository+Live`（Data層）を作成し、聖地データ取得を Repository パターンに統一
- `AppConfigRepository`（Domain層）+ `AppConfigRepository+Live`（Data層）を作成し、アプリ更新チェックを Repository パターンに統一
- `PilgrimageRemoteDataStore`、`AppConfigRemoteDataStore` を作成
- `LaunchViewModel` から `import FirebaseFirestore` を削除
- **Feature 層から `import FirebaseFirestore` が完全に排除された**

## Architecture
```
LaunchViewModel (Feature/)
  ├── @Dependency(PilgrimageRepository.self)   ← Domain/RepositoryProtocol/
  ├── @Dependency(AppConfigRepository.self)    ← Domain/RepositoryProtocol/
  ├── @Dependency(\.networkMonitor)            ← Utility/
  └── @Dependency(\.buildClient)               ← Utility/

PilgrimageRepository+Live (Data/Repository/)
  └── @Dependency(PilgrimageRemoteDataStore.self) ← Data/DataStore/Remote/

AppConfigRepository+Live (Data/Repository/)
  └── @Dependency(AppConfigRemoteDataStore.self)  ← Data/DataStore/Remote/
```

## Note
- 聖地データのローカルキャッシュ（TTL付き）は Phase 2（SwiftData 導入）で実装予定
- AppConfig はキャッシュ不要（起動時に1回チェックするだけで常に最新を取得すべき）

## Test plan
- [ ] アプリ起動時に聖地データが正常に取得・表示されること
- [ ] アプリ更新チェックが正常に動作すること
- [ ] Feature 層に `import FirebaseFirestore` が一切残っていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)