### PR TITLE
PilgrimageCardViewのPreviewProviderを#Previewマクロに移行

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Card/PilgrimageCardView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Card/PilgrimageCardView.swift
@@ -114,12 +114,9 @@ struct PilgrimageCardView: View {
     }
 }
 
-struct PilgrimageCardView_Previews: PreviewProvider {
-    static var previews: some View {
-        PilgrimageCardView(
-            pilgrimage: dummyPilgrimageList[0]
-        )
-        .frame(width: UIScreen.main.bounds.width - 64, height: UIScreen.main.bounds.width / 2 - 32)
-        .previewLayout(.sizeThatFits)
-    }
+#Preview(traits: .sizeThatFitsLayout) {
+    PilgrimageCardView(
+        pilgrimage: dummyPilgrimageList[0]
+    )
+    .frame(width: UIScreen.main.bounds.width - 64, height: UIScreen.main.bounds.width / 2 - 32)
 }


### PR DESCRIPTION
## Summary
- `PilgrimageCardView` の旧スタイル `PreviewProvider` を `#Preview` マクロに置き換え
- `.previewLayout(.sizeThatFits)` を `#Preview(traits: .sizeThatFitsLayout)` に移行

## Test plan
- [ ] Xcode の Preview が正常に表示されること

close #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)