### PR TITLE
非推奨SwiftUI修飾子を置き換える

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/CheckIn/CheckInContentView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/CheckIn/CheckInContentView.swift
@@ -19,7 +19,7 @@ struct CheckInContentView: View {
 
             Text(pilgrimageName)
                 .font(theme.fonts.bodyMedium)
-                .foregroundColor(Color(.tabPrimary))
+                .foregroundStyle(Color(.tabPrimary))
                 .lineLimit(2)
         }
     }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListView.swift
@@ -67,7 +67,7 @@ struct PilgrimageListView: View {
         }
         .background(.white)
         .border(Color(.tabPrimary), width: 1)
-        .cornerRadius(8.0)
+        .clipShape(RoundedRectangle(cornerRadius: 8.0))
     }
 
     private func pilgrimageListScrollView(geometry: GeometryProxy) -> some View {


### PR DESCRIPTION
## Summary
- `CheckInContentView` の `.foregroundColor()` を `.foregroundStyle()` に置き換え
- `PilgrimageListView` の `.cornerRadius()` を `.clipShape(RoundedRectangle(cornerRadius:))` に置き換え

## Test plan
- [ ] チェックイン画面のテキスト色が変わらないこと
- [ ] 聖地一覧画面の角丸表示が変わらないこと

close #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)