### PR TITLE
DispatchQueue.main.asyncAfterをTask.sleepに置き換える

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/PilgrimageView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/PilgrimageView.swift
@@ -26,9 +26,10 @@ struct PilgrimageView: View {
     }
 
     private func requestTrackingAuthorization() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            ATTrackingManager.requestTrackingAuthorization { _ in
-            }
+        Task {
+            // ATTダイアログは画面遷移直後に表示するとシステムに無視される場合があるため、1秒遅延させる
+            try? await Task.sleep(for: .seconds(1))
+            await ATTrackingManager.requestTrackingAuthorization()
         }
     }
 }


### PR DESCRIPTION
## Summary
- `PilgrimageView` の ATT リクエストを `DispatchQueue.main.asyncAfter` から `Task.sleep` に置き換え
- `requestTrackingAuthorization` のコールバック版を async 版に変更
- 遅延理由をコメントで明記

## Test plan
- [ ] ATT ダイアログが画面遷移後に正常に表示されること

close #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)