### PR TITLE
PilgrimageListViewの不要なNavigationStackネストを解消

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/List/PilgrimageListView.swift
@@ -71,44 +71,42 @@ struct PilgrimageListView: View {
     }
 
     private func pilgrimageListScrollView(geometry: GeometryProxy) -> some View {
-        NavigationStack {
-            ScrollView {
-                ScrollViewReader { proxy in
-                    LazyVStack(alignment: .leading) {
-                        ForEach(viewModel.searchResults) { pilgrimage in
-                            if pilgrimage.id % 5 == 0 {
-                                NativeAdvanceView()
-                                    .frame(height: geometry.size.width / 3)
-                                    .padding(.vertical, 8)
-                                    .padding(.horizontal, 16)
-                            }
-
-                            NavigationLink(
-                                destination: PilgrimageDetailView(pilgrimage: pilgrimage)
-                                    .onAppear {
-                                        viewModel.updateScrollToIndex(pilgrimage.id)
-                                    }
-                            ) {
-                                PilgrimageListContentView(
-                                    pilgrimage: pilgrimage,
-                                    isLoading: viewModel.isItemLoading(pilgrimage),
-                                    favorited: viewModel.isFavorited(pilgrimage),
-                                    onFavoriteToggle: {
-                                        Task { await viewModel.toggleFavorite(pilgrimage: pilgrimage) }
-                                    }
-                                )
-                                .frame(maxHeight: geometry.size.width / 3)
+        ScrollView {
+            ScrollViewReader { proxy in
+                LazyVStack(alignment: .leading) {
+                    ForEach(viewModel.searchResults) { pilgrimage in
+                        if pilgrimage.id % 5 == 0 {
+                            NativeAdvanceView()
+                                .frame(height: geometry.size.width / 3)
                                 .padding(.vertical, 8)
                                 .padding(.horizontal, 16)
-                                .id(pilgrimage.id)
-                            }
+                        }
+
+                        NavigationLink(
+                            destination: PilgrimageDetailView(pilgrimage: pilgrimage)
+                                .onAppear {
+                                    viewModel.updateScrollToIndex(pilgrimage.id)
+                                }
+                        ) {
+                            PilgrimageListContentView(
+                                pilgrimage: pilgrimage,
+                                isLoading: viewModel.isItemLoading(pilgrimage),
+                                favorited: viewModel.isFavorited(pilgrimage),
+                                onFavoriteToggle: {
+                                    Task { await viewModel.toggleFavorite(pilgrimage: pilgrimage) }
+                                }
+                            )
+                            .frame(maxHeight: geometry.size.width / 3)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .id(pilgrimage.id)
                         }
                     }
-                    .onAppear {
-                        proxy.scrollTo(
-                            viewModel.scrollToIndex, anchor: .center
-                        )
-                    }
+                }
+                .onAppear {
+                    proxy.scrollTo(
+                        viewModel.scrollToIndex, anchor: .center
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `pilgrimageListScrollView`内の不要な`NavigationStack`を削除
- 親の`MainView`が提供する`NavigationStack`のみを使用するように修正

## Test plan
- [ ] 聖地一覧画面でナビゲーションタイトルが正しく表示される
- [ ] リスト項目タップで詳細画面に遷移できる
- [ ] 詳細画面から戻るボタンで一覧に戻れる
- [ ] スクロール位置が復元される

close #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)