### PR TITLE
refactor: マップコードのリファクタリング

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		E795AAF12F54A0000062C9CE /* AppLogger in Frameworks */ = {isa = PBXBuildFile; productRef = E795AAF22F54A0000062C9CE /* AppLogger */; };
 		E79D8C922E43859C006170C3 /* ClusterMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79D8C912E43859C006170C3 /* ClusterMapView.swift */; };
 		E79D8C982E438635006170C3 /* PilgrimageAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79D8C972E438635006170C3 /* PilgrimageAnnotation.swift */; };
+		E7A7902B2F701DB20061403A /* MapCameraCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A7902A2F701DB20061403A /* MapCameraCommand.swift */; };
+		E7A7902D2F701E1C0061403A /* ClusterMapViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A7902C2F701E1C0061403A /* ClusterMapViewCoordinator.swift */; };
 		E7A964102BE291AB005338F3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A9640F2BE291AB005338F3 /* GoogleService-Info.plist */; };
 		E7B931432F46053A00B94C75 /* IconLicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B931412F46053A00B94C75 /* IconLicenseView.swift */; };
 		E7B931462F473AA900B94C75 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B931452F473AA900B94C75 /* MenuViewModel.swift */; };
@@ -188,6 +190,8 @@
 		E795AAEE2F5493210062C9CE /* LogMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMacroTests.swift; sourceTree = "<group>"; };
 		E79D8C912E43859C006170C3 /* ClusterMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterMapView.swift; sourceTree = "<group>"; };
 		E79D8C972E438635006170C3 /* PilgrimageAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimageAnnotation.swift; sourceTree = "<group>"; };
+		E7A7902A2F701DB20061403A /* MapCameraCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCameraCommand.swift; sourceTree = "<group>"; };
+		E7A7902C2F701E1C0061403A /* ClusterMapViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterMapViewCoordinator.swift; sourceTree = "<group>"; };
 		E7A9640F2BE291AB005338F3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E7B931412F46053A00B94C75 /* IconLicenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconLicenseView.swift; sourceTree = "<group>"; };
 		E7B931452F473AA900B94C75 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
@@ -571,6 +575,8 @@
 				E79D8C972E438635006170C3 /* PilgrimageAnnotation.swift */,
 				E7FDAA052AE029190056AA5B /* CurrentLocationButton.swift */,
 				E79D8C912E43859C006170C3 /* ClusterMapView.swift */,
+				E7A7902A2F701DB20061403A /* MapCameraCommand.swift */,
+				E7A7902C2F701E1C0061403A /* ClusterMapViewCoordinator.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -847,6 +853,7 @@
 				E79D8C982E438635006170C3 /* PilgrimageAnnotation.swift in Sources */,
 				E79045B22B0E088100F0936B /* LocationManager.swift in Sources */,
 				E72EA35B2F585C6E007BFC81 /* PilgrimageDTO.swift in Sources */,
+				E7A7902D2F701E1C0061403A /* ClusterMapViewCoordinator.swift in Sources */,
 				E72EA3672F585D20007BFC81 /* PilgrimageEntity.swift in Sources */,
 				E7FDAA042ADFEB7E0056AA5B /* PilgrimageMapConstant.swift in Sources */,
 				E72EA3622F585CAE007BFC81 /* CheckInObject.swift in Sources */,
@@ -873,6 +880,7 @@
 				E7B931482F4749AB00B94C75 /* MenuView.swift in Sources */,
 				E7FDAA172AE230310056AA5B /* UINavigationControllerExtension.swift in Sources */,
 				E72EA3582F5716D0007BFC81 /* AppConfigRepository+Live.swift in Sources */,
+				E7A7902B2F701DB20061403A /* MapCameraCommand.swift in Sources */,
 				E72EA33F2F55E7D2007BFC81 /* FavoriteRepository.swift in Sources */,
 				E795AAD02F5055BE0062C9CE /* PilgrimageListContentView.swift in Sources */,
 				E72EA34C2F570852007BFC81 /* CheckInLocalDataStore.swift in Sources */,

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/ClusterMapView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/ClusterMapView.swift
@@ -10,35 +10,13 @@ import MapKit
 
 struct ClusterMapView: UIViewRepresentable {
     @Binding var selectedIndex: Int
-    @Binding var centerCommand: CenterCommand?
+    @Binding var centerCommand: MapCameraCommand?
     let initialRegion: MKCoordinateRegion
     let initialYOffset: CGFloat
     let mapWidth: CGFloat
     let pilgrimages: [PilgrimageEntity]
     let showsUserLocation: Bool
     let onAnnotationSelected: (Int) -> Void
-    
-    struct CenterCommand: Identifiable, Equatable {
-        static func == (lhs: CenterCommand, rhs: CenterCommand) -> Bool {
-            return lhs.id == rhs.id
-        }
-        
-        init(id: UUID = UUID(),
-             target: CLLocationCoordinate2D,
-             yOffset: CGFloat,
-             animated: Bool
-        ) {
-            self.id = id
-            self.target = target
-            self.yOffset = yOffset
-            self.animated = animated
-        }
-        
-        var id = UUID()
-        let target: CLLocationCoordinate2D
-        let yOffset: CGFloat
-        let animated: Bool
-    }
     
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
@@ -84,130 +62,13 @@ struct ClusterMapView: UIViewRepresentable {
         context.coordinator.applySelectionStyle(on: mapView, selectedIndex: selectedIndex)
 
         // 親から新しい指示が来ていたら「画面座標で」ずらしてセンタリング
-        if let cmd = centerCommand, context.coordinator.lastCenterCommandID != cmd.id {
+        if let cmd = centerCommand, context.coordinator.lastCameraCommandID != cmd.id {
             context.coordinator.center(on: cmd.target, yOffset: cmd.yOffset, animated: cmd.animated)
-            context.coordinator.lastCenterCommandID = cmd.id
+            context.coordinator.lastCameraCommandID = cmd.id
         }
     }
     
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
-    }
-    
-    class Coordinator: NSObject, MKMapViewDelegate {
-        weak var mapView: MKMapView?
-        var lastCenterCommandID: UUID?
-        var parent: ClusterMapView
-        var didApplyInitialOffset = false
-
-        init(_ parent: ClusterMapView) {
-            self.parent = parent
-        }
-        
-        // 選択状態に応じてスタイル適用
-        func applySelectionStyle(on mapView: MKMapView, selectedIndex: Int) {
-            for ann in mapView.annotations {
-                guard let pa = ann as? PilgrimageAnnotation,
-                      let v = mapView.view(for: pa) else { continue }
-                if pa.index == selectedIndex {
-                    v.image = UIImage(resource: .mapPin)
-                } else {
-                    v.image = UIImage(resource: .unselectedMapPin)
-                }
-            }
-        }
-        
-        // 画面座標でオフセット → 地理座標へ変換してカメラを維持したまま移動
-        func center(on target: CLLocationCoordinate2D, yOffset: CGFloat, animated: Bool) {
-            guard let mapView else { return }
-            let pt = mapView.convert(target, toPointTo: mapView)
-            let shifted = CGPoint(x: pt.x, y: pt.y + yOffset)
-            let newCenter = mapView.convert(shifted, toCoordinateFrom: mapView)
-            
-            let cam = mapView.camera
-            let newCam = MKMapCamera(
-                lookingAtCenter: newCenter,
-                fromDistance: cam.centerCoordinateDistance, // ズーム維持
-                pitch: cam.pitch,                           // ピッチ維持
-                heading: cam.heading                        // 回転維持
-            )
-            mapView.setCamera(newCam, animated: animated)
-        }
-        
-        // クラスタアノテーションビューの設定
-        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-            // ユーザー位置のアノテーションはスキップ
-            if annotation is MKUserLocation {
-                return nil
-            }
-            
-            // クラスターアノテーション
-            if let cluster = annotation as? MKClusterAnnotation {
-                let identifier = "cluster"
-                var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? MKMarkerAnnotationView
-                
-                if annotationView == nil {
-                    annotationView = MKMarkerAnnotationView(annotation: cluster, reuseIdentifier: identifier)
-                    annotationView?.displayPriority = .defaultHigh
-                } else {
-                    annotationView?.annotation = cluster
-                }
-                
-                // クラスター内のアノテーション数を表示
-                annotationView?.markerTintColor = .systemPurple
-                annotationView?.glyphText = "\(cluster.memberAnnotations.count)"
-                return annotationView
-            }
-            
-            // 通常のピンアノテーション
-            if let pilgrimageAnnotation = annotation as? PilgrimageAnnotation {
-                let identifier = "pilgrimage"
-                var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
-                
-                if annotationView == nil {
-                    annotationView = MKAnnotationView(annotation: pilgrimageAnnotation, reuseIdentifier: identifier)
-                    annotationView?.canShowCallout = false
-                } else {
-                    annotationView?.annotation = pilgrimageAnnotation
-                }
-                
-                // カスタムピン画像を設定
-                annotationView?.image = (pilgrimageAnnotation.index == parent.selectedIndex) ? UIImage(resource: .mapPin) : UIImage(resource: .unselectedMapPin)
-                annotationView?.clusteringIdentifier = "pilgrimageCluster" // これによりクラスタリングが有効になる
-                
-                return annotationView
-            }
-            
-            return nil
-        }
-        
-        // アノテーションがタップされたときの処理
-        func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
-            if let pilgrimageAnnotation = view.annotation as? PilgrimageAnnotation {
-                // SwiftUI側の選択変更を促す
-                parent.onAnnotationSelected(pilgrimageAnnotation.index)
-                // 直ちに色反映
-                applySelectionStyle(on: mapView, selectedIndex: pilgrimageAnnotation.index)
-            }
-            
-            // クラスターがタップされた場合は拡大して表示
-            if let cluster = view.annotation as? MKClusterAnnotation {
-                // 座標が有効であることを確認
-                if CLLocationCoordinate2DIsValid(cluster.coordinate) {
-                    let currentSpan = mapView.region.span
-                    let newSpan = MKCoordinateSpan(
-                        latitudeDelta: currentSpan.latitudeDelta * 0.5,
-                        longitudeDelta: currentSpan.longitudeDelta * 0.5
-                    )
-                    
-                    let region = MKCoordinateRegion(
-                        center: cluster.coordinate,
-                        span: newSpan
-                    )
-                    
-                    mapView.setRegion(region, animated: true)
-                }
-            }
-        }
     }
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/ClusterMapViewCoordinator.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/ClusterMapViewCoordinator.swift
@@ -1,0 +1,122 @@
+//
+//  ClusterMapViewCoordinator.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/22.
+//
+
+import MapKit
+
+extension ClusterMapView {
+    class Coordinator: NSObject, MKMapViewDelegate {
+        weak var mapView: MKMapView?
+        var lastCameraCommandID: UUID?
+        var parent: ClusterMapView
+        var didApplyInitialOffset = false
+
+        init(_ parent: ClusterMapView) {
+            self.parent = parent
+        }
+
+        // MARK: - カメラ操作
+
+        /// 画面座標でオフセット → 地理座標へ変換してカメラを維持したまま移動
+        func center(on target: CLLocationCoordinate2D, yOffset: CGFloat, animated: Bool) {
+            guard let mapView else { return }
+            let pt = mapView.convert(target, toPointTo: mapView)
+            let shifted = CGPoint(x: pt.x, y: pt.y + yOffset)
+            let newCenter = mapView.convert(shifted, toCoordinateFrom: mapView)
+
+            let cam = mapView.camera
+            let newCam = MKMapCamera(
+                lookingAtCenter: newCenter,
+                fromDistance: cam.centerCoordinateDistance,
+                pitch: cam.pitch,
+                heading: cam.heading
+            )
+            mapView.setCamera(newCam, animated: animated)
+        }
+
+        // MARK: - 選択スタイル
+
+        /// 選択状態に応じてピン画像を切り替える
+        func applySelectionStyle(on mapView: MKMapView, selectedIndex: Int) {
+            for ann in mapView.annotations {
+                guard let pa = ann as? PilgrimageAnnotation,
+                      let v = mapView.view(for: pa) else { continue }
+                if pa.index == selectedIndex {
+                    v.image = UIImage(resource: .mapPin)
+                } else {
+                    v.image = UIImage(resource: .unselectedMapPin)
+                }
+            }
+        }
+
+        // MARK: - MKMapViewDelegate
+
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            if annotation is MKUserLocation {
+                return nil
+            }
+
+            if let cluster = annotation as? MKClusterAnnotation {
+                let identifier = "cluster"
+                var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? MKMarkerAnnotationView
+
+                if annotationView == nil {
+                    annotationView = MKMarkerAnnotationView(annotation: cluster, reuseIdentifier: identifier)
+                    annotationView?.displayPriority = .defaultHigh
+                } else {
+                    annotationView?.annotation = cluster
+                }
+
+                annotationView?.markerTintColor = .systemPurple
+                annotationView?.glyphText = "\(cluster.memberAnnotations.count)"
+                return annotationView
+            }
+
+            if let pilgrimageAnnotation = annotation as? PilgrimageAnnotation {
+                let identifier = "pilgrimage"
+                var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
+
+                if annotationView == nil {
+                    annotationView = MKAnnotationView(annotation: pilgrimageAnnotation, reuseIdentifier: identifier)
+                    annotationView?.canShowCallout = false
+                } else {
+                    annotationView?.annotation = pilgrimageAnnotation
+                }
+
+                annotationView?.image = (pilgrimageAnnotation.index == parent.selectedIndex) ? UIImage(resource: .mapPin) : UIImage(resource: .unselectedMapPin)
+                annotationView?.clusteringIdentifier = "pilgrimageCluster"
+
+                return annotationView
+            }
+
+            return nil
+        }
+
+        func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+            if let pilgrimageAnnotation = view.annotation as? PilgrimageAnnotation {
+                parent.onAnnotationSelected(pilgrimageAnnotation.index)
+                applySelectionStyle(on: mapView, selectedIndex: pilgrimageAnnotation.index)
+            }
+
+            if let cluster = view.annotation as? MKClusterAnnotation {
+                if CLLocationCoordinate2DIsValid(cluster.coordinate) {
+                    let currentSpan = mapView.region.span
+                    let newSpan = MKCoordinateSpan(
+                        latitudeDelta: currentSpan.latitudeDelta * 0.5,
+                        longitudeDelta: currentSpan.longitudeDelta * 0.5
+                    )
+
+                    let region = MKCoordinateRegion(
+                        center: cluster.coordinate,
+                        span: newSpan
+                    )
+
+                    mapView.setRegion(region, animated: true)
+                }
+            }
+        }
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/MapCameraCommand.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/MapCameraCommand.swift
@@ -1,0 +1,33 @@
+//
+//  MapCameraCommand.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/03/22.
+//
+
+import CoreLocation
+import Foundation
+
+/// マップカメラの移動を指示するコマンド。
+/// 指定した座標にカメラを移動し、カード領域を考慮した Y オフセットで表示位置を調整する。
+struct MapCameraCommand: Identifiable, Equatable {
+    static func == (lhs: MapCameraCommand, rhs: MapCameraCommand) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    init(id: UUID = UUID(),
+         target: CLLocationCoordinate2D,
+         yOffset: CGFloat,
+         animated: Bool
+    ) {
+        self.id = id
+        self.target = target
+        self.yOffset = yOffset
+        self.animated = animated
+    }
+
+    var id = UUID()
+    let target: CLLocationCoordinate2D
+    let yOffset: CGFloat
+    let animated: Bool
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/PilgrimageMapView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Map/PilgrimageMapView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct PilgrimageMapView: View {
     @Environment(\.theme) private var theme
     @State private var selectedIndex: Int
-    @State private var centerCommand: ClusterMapView.CenterCommand?
+    @State private var centerCommand: MapCameraCommand?
     @State private var isShowAlert = false
     @State private var containerWidth: CGFloat = 0
     @State private var hasSetInitialLocation = false


### PR DESCRIPTION
## Summary
- `ClusterMapView.Coordinator` を `ClusterMapViewCoordinator.swift` に分離
- `ClusterMapView.CenterCommand` を `MapCameraCommand` にリネームし独立ファイルに切り出し
- 関連する変数名 `lastCenterCommandID` → `lastCameraCommandID` に統一

## Test plan
- [ ] マップ画面でピンが表示され、タップで選択状態が切り替わること
- [ ] カードスワイプでマップの中心が対応する聖地に移動すること
- [ ] 現在地ボタンタップでマップが現在地に移動すること
- [ ] クラスタータップでマップが拡大されること
- [ ] リファクタ前後でマップの表示・操作に差異がないこと

close #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)