### PR TITLE
既存UUIDデータのFirebase Auth IDへの移行

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		E7738FA32BB45AA700C00F2F /* RouteActionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7738FA22BB45AA700C00F2F /* RouteActionClient.swift */; };
 		E78276092BAC796000AD16CC /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78276082BAC796000AD16CC /* NetworkMonitor.swift */; };
 		E79045B22B0E088100F0936B /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79045B12B0E088100F0936B /* LocationManager.swift */; };
+		E79352E72F867F8200940B3B /* CheckInMigrationClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352E62F867F8200940B3B /* CheckInMigrationClient.swift */; };
+		E79352E92F8682E600940B3B /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352E82F8682E600940B3B /* UserDefaultsKey.swift */; };
+		E79352EC2F86843E00940B3B /* LaunchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352EB2F86843E00940B3B /* LaunchViewModelTests.swift */; };
 		E79384C32F7EA3F700ED2D11 /* AuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79384C22F7EA3F700ED2D11 /* AuthUser.swift */; };
 		E79384C62F7EA42800ED2D11 /* AuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79384C52F7EA42800ED2D11 /* AuthState.swift */; };
 		E79384C82F7EA43600ED2D11 /* AuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79384C72F7EA43600ED2D11 /* AuthError.swift */; };
@@ -205,6 +208,9 @@
 		E7738FA22BB45AA700C00F2F /* RouteActionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteActionClient.swift; sourceTree = "<group>"; };
 		E78276082BAC796000AD16CC /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		E79045B12B0E088100F0936B /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		E79352E62F867F8200940B3B /* CheckInMigrationClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInMigrationClient.swift; sourceTree = "<group>"; };
+		E79352E82F8682E600940B3B /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
+		E79352EB2F86843E00940B3B /* LaunchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewModelTests.swift; sourceTree = "<group>"; };
 		E79384C22F7EA3F700ED2D11 /* AuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUser.swift; sourceTree = "<group>"; };
 		E79384C52F7EA42800ED2D11 /* AuthState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthState.swift; sourceTree = "<group>"; };
 		E79384C72F7EA43600ED2D11 /* AuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthError.swift; sourceTree = "<group>"; };
@@ -345,6 +351,7 @@
 				E757BB032E8AD58500035318 /* ReadableContentGuideModifier.swift */,
 				E72EA3742F59C948007BFC81 /* SafariView.swift */,
 				E7A7903F2F7163B10061403A /* Constants.swift */,
+				E79352E82F8682E600940B3B /* UserDefaultsKey.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -484,6 +491,7 @@
 			isa = PBXGroup;
 			children = (
 				E72EA36D2F586FEF007BFC81 /* FavoriteMigrationClient.swift */,
+				E79352E62F867F8200940B3B /* CheckInMigrationClient.swift */,
 			);
 			path = Migration;
 			sourceTree = "<group>";
@@ -612,6 +620,14 @@
 				E76BF1642BD16FE700A1CB97 /* NativeAdvanceView.swift */,
 			);
 			path = NativeAdvance;
+			sourceTree = "<group>";
+		};
+		E79352EA2F86843100940B3B /* Launch */ = {
+			isa = PBXGroup;
+			children = (
+				E79352EB2F86843E00940B3B /* LaunchViewModelTests.swift */,
+			);
+			path = Launch;
 			sourceTree = "<group>";
 		};
 		E79384C42F7EA41500ED2D11 /* Auth */ = {
@@ -777,6 +793,7 @@
 		E7A790302F7024120061403A /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				E79352EA2F86843100940B3B /* Launch */,
 				E7D0DC982F840D5A002C877E /* SignInPromotion */,
 				E75C9C702F839E41004DEF09 /* Menu */,
 				E7A7905F2F7C03AE0061403A /* CheckInCompletion */,
@@ -1194,6 +1211,7 @@
 				E7A7902F2F7023F50061403A /* PilgrimageMapViewModel.swift in Sources */,
 				E7A790382F7102F40061403A /* CheckInEntity.swift in Sources */,
 				E72EA3542F5716B2007BFC81 /* AppConfigRemoteDataStore.swift in Sources */,
+				E79352E72F867F8200940B3B /* CheckInMigrationClient.swift in Sources */,
 				E79384D02F7EA62900ED2D11 /* SignOutUseCase.swift in Sources */,
 				E76BF15E2BD1630C00A1CB97 /* NativeAdvanceViewController.swift in Sources */,
 				E79D8C982E438635006170C3 /* PilgrimageAnnotation.swift in Sources */,
@@ -1254,6 +1272,7 @@
 				E72EA3412F55E7DF007BFC81 /* FavoriteRepository+Live.swift in Sources */,
 				E76BF1652BD16FE700A1CB97 /* NativeAdvanceView.swift in Sources */,
 				E72EA3442F5703B1007BFC81 /* CheckInRemoteDataStore.swift in Sources */,
+				E79352E92F8682E600940B3B /* UserDefaultsKey.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1269,6 +1288,7 @@
 				E7A790522F7BF0200061403A /* RelatedMediaDTOTests.swift in Sources */,
 				E7A7903E2F715BA90061403A /* CheckInUseCaseTests.swift in Sources */,
 				E7D0DC9A2F840D6B002C877E /* SignInPromotionViewModelTests.swift in Sources */,
+				E79352EC2F86843E00940B3B /* LaunchViewModelTests.swift in Sources */,
 				E7A790442F71659F0061403A /* CheckInRepositoryTests.swift in Sources */,
 				E75C9C722F839E51004DEF09 /* MenuViewModelTests.swift in Sources */,
 			);

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Local/CheckInLocalDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Local/CheckInLocalDataStore.swift
@@ -29,15 +29,13 @@ struct CheckInLocalDataStore {
 }
 
 extension CheckInLocalDataStore: DependencyKey {
-    private static let hasLoadedKey = "hasLoadedCheckInsOnce"
-
     static let liveValue: Self = {
         @Dependency(SwiftDataClient.self) var swiftDataClient
         let sortByCheckedInAt = SortDescriptor(\CheckInObject.checkedInAt)
 
         return .init(
             getAll: {
-                guard UserDefaults.standard.bool(forKey: hasLoadedKey) else { return nil }
+                guard UserDefaults.standard.bool(forKey: UserDefaultsKey.hasLoadedCheckInsOnce.rawValue) else { return nil }
                 let context = ModelContext(try swiftDataClient.container())
                 let descriptor = FetchDescriptor<CheckInObject>(
                     sortBy: [sortByCheckedInAt]
@@ -57,7 +55,7 @@ extension CheckInLocalDataStore: DependencyKey {
                     )
                 }
                 try context.save()
-                UserDefaults.standard.set(true, forKey: hasLoadedKey)
+                UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasLoadedCheckInsOnce.rawValue)
             },
             add: { code, checkedInAt, memo in
                 let context = ModelContext(try swiftDataClient.container())

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/CheckInRemoteDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/CheckInRemoteDataStore.swift
@@ -23,6 +23,9 @@ struct CheckInRemoteDataStore {
 }
 
 extension CheckInRemoteDataStore: DependencyKey {
+    static let rootCollection = "checked-in-list"
+    static let listSubcollection = "list"
+
     static let liveValue: Self = {
         return .init(
             fetchAll: {
@@ -65,10 +68,16 @@ extension CheckInRemoteDataStore: DependencyKey {
     }()
 
     private static func collectionRef() async -> CollectionReference {
-        let uuid = await UIDevice.current.identifierForVendor!.uuidString
+        @Dependency(AuthRepository.self) var authRepository
+        let documentId: String
+        if let user = authRepository.currentUser() {
+            documentId = user.uid
+        } else {
+            documentId = await UIDevice.current.identifierForVendor!.uuidString
+        }
         return Firestore.firestore()
-            .collection("checked-in-list")
-            .document(uuid)
-            .collection("list")
+            .collection(rootCollection)
+            .document(documentId)
+            .collection(listSubcollection)
     }
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Migration/CheckInMigrationClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Migration/CheckInMigrationClient.swift
@@ -1,0 +1,8 @@
+//
+//  CheckInMigrationClient.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/04/08.
+//
+
+import Foundation

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Migration/CheckInMigrationClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Migration/CheckInMigrationClient.swift
@@ -5,4 +5,67 @@
 //  Created by k_kudo on 2026/04/08.
 //
 
+import AppLogger
+import Dependencies
+import DependenciesMacros
+import FirebaseFirestore
 import Foundation
+import UIKit
+
+@DependencyClient
+struct CheckInMigrationClient {
+    var migrateIfNeeded: @Sendable () async -> Void
+}
+
+extension CheckInMigrationClient: DependencyKey {
+    static let liveValue: Self = {
+        @Dependency(AuthRepository.self) var authRepository
+        // UserDefaultsフラグの読み取りからFirestore書き込み完了までにタイムウィンドウがあり、
+        // その間に別スレッドから呼ばれると同じデータが二重コピーされる。
+        // インメモリフラグで排他制御し、同時実行を防ぐ。
+        let isMigrating = LockIsolated(false)
+
+        return .init(
+            migrateIfNeeded: {
+                let didStart = isMigrating.withValue { flag -> Bool in
+                    guard !flag else { return false }
+                    flag = true
+                    return true
+                }
+                guard didStart else { return }
+                defer { isMigrating.setValue(false) }
+
+                guard !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasCompletedCheckInMigration.rawValue) else {
+                    return
+                }
+                guard let user = authRepository.currentUser() else { return }
+                guard let uuid = await UIDevice.current.identifierForVendor?.uuidString else { return }
+
+                do {
+                    let db = Firestore.firestore()
+                    let root = CheckInRemoteDataStore.rootCollection
+                    let sub = CheckInRemoteDataStore.listSubcollection
+
+                    let sourceRef = db.collection(root).document(uuid).collection(sub)
+                    let snapshot = try await sourceRef.getDocuments()
+
+                    guard !snapshot.documents.isEmpty else {
+                        UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasCompletedCheckInMigration.rawValue)
+                        return
+                    }
+
+                    let destRef = db.collection(root).document(user.uid).collection(sub)
+                    let batch = db.batch()
+                    for doc in snapshot.documents {
+                        batch.setData(doc.data(), forDocument: destRef.document(doc.documentID))
+                    }
+                    try await batch.commit()
+
+                    UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasCompletedCheckInMigration.rawValue)
+                } catch {
+                    #log(.error, "Check-in migration failed: \(error.localizedDescription)")
+                }
+            }
+        )
+    }()
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Migration/FavoriteMigrationClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/Migration/FavoriteMigrationClient.swift
@@ -16,20 +16,18 @@ struct FavoriteMigrationClient {
 }
 
 extension FavoriteMigrationClient: DependencyKey {
-    private static let hasMigratedKey = "hasMigratedFavoritesToLocal"
-
     static let liveValue: Self = {
         @Dependency(FavoriteRemoteDataStore.self) var remoteDataStore
         @Dependency(FavoriteLocalDataStore.self) var localDataStore
 
         return .init(
             migrateIfNeeded: {
-                guard !UserDefaults.standard.bool(forKey: hasMigratedKey) else { return }
+                guard !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasMigratedFavoritesToLocal.rawValue) else { return }
                 do {
                     let dtos = try await remoteDataStore.fetchAll()
                     let codes = dtos.map(\.code)
                     try await localDataStore.setAll(codes)
-                    UserDefaults.standard.set(true, forKey: hasMigratedKey)
+                    UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasMigratedFavoritesToLocal.rawValue)
                 } catch {
                     #log(.error, "Favorite migration failed: \(error.localizedDescription)")
                 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Debug/DebugMenuView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Debug/DebugMenuView.swift
@@ -13,19 +13,17 @@ struct DebugMenuView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showSignInPromotion = false
     @State private var signInPromotionContext: SignInPromotionContext = .launch
+    // UserDefaultsや認証状態の変更後にViewの再描画を強制するためのカウンター
+    @State private var refreshCounter = 0
 
     @Dependency(SignInPromotionClient.self) private var signInPromotionClient
     @Dependency(AuthRepository.self) private var authRepository
 
     private var userDefaultsItems: [(key: String, value: String)] {
-        let keys = [
-            Constants.UserDefaultsKey.lastSignInPromptVersion,
-            "hasMigratedFavoritesToLocal",
-            "hasLoadedCheckInsOnce",
-        ]
-        return keys.map { key in
-            let value = UserDefaults.standard.object(forKey: key)
-            return (key: key, value: value.map { "\($0)" } ?? "(nil)")
+        _ = refreshCounter
+        return UserDefaultsKey.allCases.map { key in
+            let value = UserDefaults.standard.object(forKey: key.rawValue)
+            return (key: key.rawValue, value: value.map { "\($0)" } ?? "(nil)")
         }
     }
 
@@ -43,7 +41,16 @@ struct DebugMenuView: View {
                         showSignInPromotion = true
                     }
                     Button("表示済みフラグをリセット") {
-                        UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKey.lastSignInPromptVersion)
+                        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.lastSignInPromptVersion.rawValue)
+                        refreshCounter += 1
+                    }
+                }
+
+                // MARK: - データ移行
+                Section("データ移行") {
+                    Button("チェックイン移行フラグをリセット") {
+                        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.hasCompletedCheckInMigration.rawValue)
+                        refreshCounter += 1
                     }
                 }
 
@@ -58,6 +65,7 @@ struct DebugMenuView: View {
                             .foregroundStyle(Color(.secondaryLabel))
                         Button("サインアウト", role: .destructive) {
                             try? authRepository.signOut()
+                            refreshCounter += 1
                         }
                     } else {
                         Text("未サインイン")

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchView.swift
@@ -23,7 +23,7 @@ struct LaunchView: View {
             .environment(locationManager)
             .fullScreenCover(isPresented: $viewModel.shouldShowSignInPromotion) {
                 SignInPromotionView(context: .launch) { _ in
-                    viewModel.dismissSignInPromotion()
+                    Task { await viewModel.dismissSignInPromotion() }
                 }
             }
         } else {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchViewModel.swift
@@ -22,6 +22,8 @@ final class LaunchViewModel {
     @ObservationIgnored
     @Dependency(FavoriteMigrationClient.self) var favoriteMigration
     @ObservationIgnored
+    @Dependency(CheckInMigrationClient.self) var checkInMigration
+    @ObservationIgnored
     @Dependency(SignInPromotionClient.self) var signInPromotionClient
 
     var pilgrimages: [PilgrimageEntity] = []
@@ -55,13 +57,15 @@ final class LaunchViewModel {
     func initialize() async {
         await checkForUpdate()
         await favoriteMigration.migrateIfNeeded()
+        await checkInMigration.migrateIfNeeded()
         await fetchAllPilgrimages()
         shouldShowSignInPromotion = signInPromotionClient.shouldShowOnLaunch()
     }
 
-    func dismissSignInPromotion() {
+    func dismissSignInPromotion() async {
         shouldShowSignInPromotion = false
         signInPromotionClient.markPromptShown()
+        await checkInMigration.migrateIfNeeded()
     }
 
     func fetchAllPilgrimages() async {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Menu/MenuViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Menu/MenuViewModel.swift
@@ -65,6 +65,8 @@ final class MenuViewModel {
     @Dependency(SignInUseCase.self) private var signInUseCase
     @ObservationIgnored
     @Dependency(SignOutUseCase.self) private var signOutUseCase
+    @ObservationIgnored
+    @Dependency(CheckInMigrationClient.self) private var checkInMigration
 
     var appVersion: String {
         buildClient.appVersion()
@@ -85,6 +87,7 @@ final class MenuViewModel {
         defer { isSigningIn = false }
         do {
             _ = try await signInUseCase.execute()
+            await checkInMigration.migrateIfNeeded()
         } catch AuthError.cancelled {
             // ユーザーがキャンセルした場合は何もしない
         } catch {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
@@ -24,6 +24,8 @@ final class PilgrimageDetailViewModel {
     @ObservationIgnored
     @Dependency(SignInPromotionClient.self) var signInPromotionClient
     @ObservationIgnored
+    @Dependency(CheckInMigrationClient.self) var checkInMigration
+    @ObservationIgnored
     @Dependency(\.date) var date
 
     var isLoading = false
@@ -91,6 +93,7 @@ final class PilgrimageDetailViewModel {
         showSignInPromotion = false
         if signedIn, let pending = pendingCheckIn {
             pendingCheckIn = nil
+            await checkInMigration.migrateIfNeeded()
             await performCheckIn(pilgrimage: pending.pilgrimage, userCoordinate: pending.userCoordinate)
         } else {
             pendingCheckIn = nil

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/Auth/SignInPromotionClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/Auth/SignInPromotionClient.swift
@@ -27,7 +27,7 @@ extension SignInPromotionClient: DependencyKey {
         return .init(
             shouldShowOnLaunch: {
                 guard authRepository.currentUser() == nil else { return false }
-                let lastVersion = UserDefaults.standard.string(forKey: Constants.UserDefaultsKey.lastSignInPromptVersion)
+                let lastVersion = UserDefaults.standard.string(forKey: UserDefaultsKey.lastSignInPromptVersion.rawValue)
                 return lastVersion != buildClient.appVersion()
             },
             shouldShowOnCheckIn: {
@@ -35,7 +35,7 @@ extension SignInPromotionClient: DependencyKey {
             },
             markPromptShown: {
                 let version = buildClient.appVersion()
-                UserDefaults.standard.set(version, forKey: Constants.UserDefaultsKey.lastSignInPromptVersion)
+                UserDefaults.standard.set(version, forKey: UserDefaultsKey.lastSignInPromptVersion.rawValue)
             }
         )
     }()

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/Constants.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/Constants.swift
@@ -17,10 +17,6 @@ enum Constants {
         }
     }
 
-    enum UserDefaultsKey {
-        static let lastSignInPromptVersion = "lastSignInPromptVersion"
-    }
-
     #if DEBUG
     enum Notification {
         static let deviceDidShake = NSNotification.Name("deviceDidShake")

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/UserDefaultsKey.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/UserDefaultsKey.swift
@@ -1,0 +1,19 @@
+//
+//  UserDefaultsKey.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/04/08.
+//
+
+import Foundation
+
+enum UserDefaultsKey: String, CaseIterable {
+    /// サインイン促進を最後に表示したアプリバージョン
+    case lastSignInPromptVersion
+    /// お気に入りデータのローカル移行が完了したか
+    case hasMigratedFavoritesToLocal
+    /// チェックイン記録のリモート→ローカル初回読み込みが完了したか
+    case hasLoadedCheckInsOnce
+    /// UUID→Firebase Auth IDへのチェックインデータ移行が完了したか
+    case hasCompletedCheckInMigration
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Launch/LaunchViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Launch/LaunchViewModelTests.swift
@@ -1,0 +1,16 @@
+//
+//  LaunchViewModelTests.swift
+//  nogizaka-pilgrimageTests
+//
+//  Created by k_kudo on 2026/04/08.
+//
+
+import Testing
+
+struct LaunchViewModelTests {
+
+    @Test func <#test function name#>() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Launch/LaunchViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Launch/LaunchViewModelTests.swift
@@ -5,12 +5,64 @@
 //  Created by k_kudo on 2026/04/08.
 //
 
+import Dependencies
+import Foundation
 import Testing
 
+@testable import nogizaka_pilgrimage
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
 struct LaunchViewModelTests {
 
-    @Test func <#test function name#>() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // MARK: - マイグレーション
+
+    @Test("initialize()でチェックインマイグレーションが実行される")
+    func initialize_callsCheckInMigration() async {
+        let migrationCalled = LockIsolated(false)
+
+        let viewModel = withDependencies {
+            $0[BuildClient.self].appVersion = { "1.0.0" }
+            $0[FavoriteMigrationClient.self].migrateIfNeeded = {}
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {
+                migrationCalled.setValue(true)
+            }
+            $0[NetworkMonitor.self].monitorNetwork = {}
+            $0[AppConfigRepository.self].fetchUpdateInfo = {
+                AppUpdateInfoDTO(
+                    targetVersion: "1.0.0",
+                    isForce: false,
+                    title: "",
+                    message: "",
+                    appStoreURL: ""
+                )
+            }
+            $0[PilgrimageRepository.self].fetchAllPilgrimages = { dummyPilgrimageList }
+            $0[SignInPromotionClient.self].shouldShowOnLaunch = { false }
+        } operation: {
+            LaunchViewModel()
+        }
+
+        await viewModel.initialize()
+
+        #expect(migrationCalled.value == true)
     }
 
+    @Test("dismissSignInPromotion()でチェックインマイグレーションが実行される")
+    func dismissSignInPromotion_callsCheckInMigration() async {
+        let migrationCalled = LockIsolated(false)
+
+        let viewModel = withDependencies {
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {
+                migrationCalled.setValue(true)
+            }
+            $0[SignInPromotionClient.self].markPromptShown = {}
+        } operation: {
+            LaunchViewModel()
+        }
+
+        await viewModel.dismissSignInPromotion()
+
+        #expect(migrationCalled.value == true)
+    }
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Menu/MenuViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Menu/MenuViewModelTests.swift
@@ -71,6 +71,7 @@ struct MenuViewModelTests {
     func signIn_success_resetsIsSigningIn() async {
         let viewModel = withDependencies {
             $0[SignInUseCase.self].execute = { testUser }
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {}
         } operation: {
             MenuViewModel()
         }
@@ -79,6 +80,24 @@ struct MenuViewModelTests {
 
         #expect(viewModel.isSigningIn == false)
         #expect(viewModel.activeAlert == nil)
+    }
+
+    @Test("signInWithAppleで成功時にチェックインマイグレーションが実行される")
+    func signIn_success_callsMigration() async {
+        let migrationCalled = LockIsolated(false)
+
+        let viewModel = withDependencies {
+            $0[SignInUseCase.self].execute = { testUser }
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {
+                migrationCalled.setValue(true)
+            }
+        } operation: {
+            MenuViewModel()
+        }
+
+        await viewModel.signInWithApple()
+
+        #expect(migrationCalled.value == true)
     }
 
     @Test("signInWithAppleでキャンセル時にアラートが表示されない")
@@ -95,6 +114,24 @@ struct MenuViewModelTests {
         #expect(viewModel.isSigningIn == false)
     }
 
+    @Test("signInWithAppleでキャンセル時にマイグレーションは実行されない")
+    func signIn_cancelled_doesNotCallMigration() async {
+        let migrationCalled = LockIsolated(false)
+
+        let viewModel = withDependencies {
+            $0[SignInUseCase.self].execute = { throw AuthError.cancelled }
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {
+                migrationCalled.setValue(true)
+            }
+        } operation: {
+            MenuViewModel()
+        }
+
+        await viewModel.signInWithApple()
+
+        #expect(migrationCalled.value == false)
+    }
+
     @Test("signInWithAppleでエラー時にsignInErrorアラートが表示される")
     func signIn_error_showsAlert() async {
         let viewModel = withDependencies {
@@ -107,6 +144,24 @@ struct MenuViewModelTests {
 
         #expect(viewModel.activeAlert == .signInError)
         #expect(viewModel.isSigningIn == false)
+    }
+
+    @Test("signInWithAppleでエラー時にマイグレーションは実行されない")
+    func signIn_error_doesNotCallMigration() async {
+        let migrationCalled = LockIsolated(false)
+
+        let viewModel = withDependencies {
+            $0[SignInUseCase.self].execute = { throw AuthError.signInFailed }
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {
+                migrationCalled.setValue(true)
+            }
+        } operation: {
+            MenuViewModel()
+        }
+
+        await viewModel.signInWithApple()
+
+        #expect(migrationCalled.value == false)
     }
 
     // MARK: - signOut

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Pilgrimage/Detail/PilgrimageDetailViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Pilgrimage/Detail/PilgrimageDetailViewModelTests.swift
@@ -75,6 +75,7 @@ struct PilgrimageDetailViewModelTests {
             $0[CheckInUseCase.self].execute = { _, _ in
                 checkInCalled.setValue(true)
             }
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {}
             $0[NetworkMonitor.self].monitorNetwork = {}
             $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
         } operation: {
@@ -90,6 +91,30 @@ struct PilgrimageDetailViewModelTests {
 
         #expect(viewModel.showSignInPromotion == false)
         #expect(checkInCalled.value == true)
+    }
+
+    @Test("サインイン成功後にマイグレーションがチェックインより先に実行される")
+    func onPromotionCompleted_signedIn_migratesBeforeCheckIn() async {
+        let callOrder = LockIsolated<[String]>([])
+
+        let viewModel = withDependencies {
+            $0[SignInPromotionClient.self].shouldShowOnCheckIn = { true }
+            $0[CheckInMigrationClient.self].migrateIfNeeded = {
+                callOrder.withValue { $0.append("migration") }
+            }
+            $0[CheckInUseCase.self].execute = { _, _ in
+                callOrder.withValue { $0.append("checkIn") }
+            }
+            $0[NetworkMonitor.self].monitorNetwork = {}
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+        } operation: {
+            PilgrimageDetailViewModel()
+        }
+
+        await viewModel.checkIn(pilgrimage: testPilgrimage, userCoordinate: testCoordinate)
+        await viewModel.onSignInPromotionCompleted(signedIn: true)
+
+        #expect(callOrder.value == ["migration", "checkIn"])
     }
 
     @Test("サインイン失敗後はpendingCheckInがクリアされる")


### PR DESCRIPTION
## Summary
- `CheckInMigrationClient` を追加し、サインイン成功時にUUID配下のチェックインデータをAuth ID配下にFirestoreバッチ書き込みでコピー
- `CheckInRemoteDataStore.collectionRef()` をサインイン状態に応じてAuth ID / UUIDで切り替え
- UserDefaultsキーを `CaseIterable` な `UserDefaultsKey` enumに集約し、デバッグメニューで自動列挙

## Test plan
- [ ] 未サインイン状態で既存チェックイン済みスポットが表示される（UUID参照）
- [ ] サインイン後、既存チェックイン済みスポットが引き続き表示される（Auth ID参照、移行済み）
- [ ] サインイン後に新規チェックインが正常に動作する
- [ ] アプリを再起動してもデータが保持されている
- [ ] 2回目のサインインでマイグレーションが再実行されないこと（デバッグメニューのUserDefaultsで確認）
- [ ] UUIDにデータが存在しない新規ユーザーでもエラーにならないこと
- [ ] ユニットテストがパスすること

close #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)