### PR TITLE
Remote Configによる認証移行制御の実装

### DIFF
--- a/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage.xcodeproj/project.pbxproj
@@ -64,6 +64,10 @@
 		E79352E72F867F8200940B3B /* CheckInMigrationClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352E62F867F8200940B3B /* CheckInMigrationClient.swift */; };
 		E79352E92F8682E600940B3B /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352E82F8682E600940B3B /* UserDefaultsKey.swift */; };
 		E79352EC2F86843E00940B3B /* LaunchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352EB2F86843E00940B3B /* LaunchViewModelTests.swift */; };
+		E79352EF2F87FB2600940B3B /* RemoteConfigClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352EE2F87FB2600940B3B /* RemoteConfigClient.swift */; };
+		E79352F12F87FC2800940B3B /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = E79352F02F87FC2800940B3B /* FirebaseRemoteConfig */; };
+		E79352F42F87FED600940B3B /* RemoteConfigParameterKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352F32F87FED600940B3B /* RemoteConfigParameterKey.swift */; };
+		E79352F62F8936BD00940B3B /* DebugRemoteConfigClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79352F52F8936BD00940B3B /* DebugRemoteConfigClient.swift */; };
 		E79384C32F7EA3F700ED2D11 /* AuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79384C22F7EA3F700ED2D11 /* AuthUser.swift */; };
 		E79384C62F7EA42800ED2D11 /* AuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79384C52F7EA42800ED2D11 /* AuthState.swift */; };
 		E79384C82F7EA43600ED2D11 /* AuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79384C72F7EA43600ED2D11 /* AuthError.swift */; };
@@ -211,6 +215,9 @@
 		E79352E62F867F8200940B3B /* CheckInMigrationClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInMigrationClient.swift; sourceTree = "<group>"; };
 		E79352E82F8682E600940B3B /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		E79352EB2F86843E00940B3B /* LaunchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewModelTests.swift; sourceTree = "<group>"; };
+		E79352EE2F87FB2600940B3B /* RemoteConfigClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigClient.swift; sourceTree = "<group>"; };
+		E79352F32F87FED600940B3B /* RemoteConfigParameterKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigParameterKey.swift; sourceTree = "<group>"; };
+		E79352F52F8936BD00940B3B /* DebugRemoteConfigClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRemoteConfigClient.swift; sourceTree = "<group>"; };
 		E79384C22F7EA3F700ED2D11 /* AuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUser.swift; sourceTree = "<group>"; };
 		E79384C52F7EA42800ED2D11 /* AuthState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthState.swift; sourceTree = "<group>"; };
 		E79384C72F7EA43600ED2D11 /* AuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthError.swift; sourceTree = "<group>"; };
@@ -290,6 +297,7 @@
 				E795AAF12F54A0000062C9CE /* AppLogger in Frameworks */,
 				E747728F2D958B0100F659EF /* GoogleMobileAds in Frameworks */,
 				E7B9CD592B8E26E9003FAB19 /* FirebaseFirestore in Frameworks */,
+				E79352F12F87FC2800940B3B /* FirebaseRemoteConfig in Frameworks */,
 				E7B9CD5B2B8E26E9003FAB20 /* FirebaseAuth in Frameworks */,
 				E7C72A662E5F517300FC2378 /* CustomDump in Frameworks */,
 				E795AADA2F51A2AB0062C9CE /* Dependencies in Frameworks */,
@@ -381,6 +389,7 @@
 		E72EA3342F55D514007BFC81 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				E79352ED2F87FB1300940B3B /* RemoteConfig */,
 				E72EA36C2F586FE4007BFC81 /* Migration */,
 				E72EA3592F585C5B007BFC81 /* DTO */,
 				E72EA3372F55E75A007BFC81 /* DataStore */,
@@ -628,6 +637,24 @@
 				E79352EB2F86843E00940B3B /* LaunchViewModelTests.swift */,
 			);
 			path = Launch;
+			sourceTree = "<group>";
+		};
+		E79352ED2F87FB1300940B3B /* RemoteConfig */ = {
+			isa = PBXGroup;
+			children = (
+				E79352F22F87FEC100940B3B /* RemoteConfigParameter */,
+				E79352EE2F87FB2600940B3B /* RemoteConfigClient.swift */,
+				E79352F52F8936BD00940B3B /* DebugRemoteConfigClient.swift */,
+			);
+			path = RemoteConfig;
+			sourceTree = "<group>";
+		};
+		E79352F22F87FEC100940B3B /* RemoteConfigParameter */ = {
+			isa = PBXGroup;
+			children = (
+				E79352F32F87FED600940B3B /* RemoteConfigParameterKey.swift */,
+			);
+			path = RemoteConfigParameter;
 			sourceTree = "<group>";
 		};
 		E79384C42F7EA41500ED2D11 /* Auth */ = {
@@ -1025,6 +1052,7 @@
 				E795AADB2F51A2AB0062C9CE /* DependenciesMacros */,
 				E7F4023D2F60555500226464 /* NukeUI */,
 				E79AC7EC2F7D617700754C51 /* Lottie */,
+				E79352F02F87FC2800940B3B /* FirebaseRemoteConfig */,
 			);
 			productName = "nogizaka-pilgrimage";
 			productReference = E74934422959F20E0045AE39 /* nogizaka-pilgrimage.app */;
@@ -1190,6 +1218,7 @@
 				E7B931432F46053A00B94C75 /* IconLicenseView.swift in Sources */,
 				E72EA3482F57042C007BFC81 /* CheckInRepository+Live.swift in Sources */,
 				E79384C62F7EA42800ED2D11 /* AuthState.swift in Sources */,
+				E79352F62F8936BD00940B3B /* DebugRemoteConfigClient.swift in Sources */,
 				E7D0DC8F2F84080C002C877E /* SignInPromotionContext.swift in Sources */,
 				E795AAC82F50558E0062C9CE /* PilgrimageCardViewModel.swift in Sources */,
 				E73E09122965C21E00A1204E /* MainView.swift in Sources */,
@@ -1214,6 +1243,7 @@
 				E79352E72F867F8200940B3B /* CheckInMigrationClient.swift in Sources */,
 				E79384D02F7EA62900ED2D11 /* SignOutUseCase.swift in Sources */,
 				E76BF15E2BD1630C00A1CB97 /* NativeAdvanceViewController.swift in Sources */,
+				E79352F42F87FED600940B3B /* RemoteConfigParameterKey.swift in Sources */,
 				E79D8C982E438635006170C3 /* PilgrimageAnnotation.swift in Sources */,
 				E79045B22B0E088100F0936B /* LocationManager.swift in Sources */,
 				E72EA35B2F585C6E007BFC81 /* PilgrimageDTO.swift in Sources */,
@@ -1230,6 +1260,7 @@
 				E72EA36B2F5866D0007BFC81 /* PilgrimageLocalDataStore.swift in Sources */,
 				E795AACC2F5055AA0062C9CE /* PilgrimageListViewModel.swift in Sources */,
 				E72EA3702F59B1BB007BFC81 /* AppUpdateInfoDTO.swift in Sources */,
+				E79352EF2F87FB2600940B3B /* RemoteConfigClient.swift in Sources */,
 				E71A82792BE200B700C16FEE /* BuildClient.swift in Sources */,
 				E79D8C922E43859C006170C3 /* ClusterMapView.swift in Sources */,
 				E72EA3602F585CA1007BFC81 /* FavoriteObject.swift in Sources */,
@@ -1860,6 +1891,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E747728D2D958B0100F659EF /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
 			productName = GoogleMobileAds;
+		};
+		E79352F02F87FC2800940B3B /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E7B9CD552B8E26E9003FAB19 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 		E795AAD92F51A2AB0062C9CE /* Dependencies */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/CheckInRemoteDataStore.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/DataStore/Remote/CheckInRemoteDataStore.swift
@@ -29,36 +29,39 @@ extension CheckInRemoteDataStore: DependencyKey {
     static let liveValue: Self = {
         return .init(
             fetchAll: {
+                guard let ref = await collectionRef() else { return [] }
                 do {
-                    let snapshot = try await collectionRef().getDocuments()
+                    let snapshot = try await ref.getDocuments()
                     return try snapshot.documents.map { try $0.data(as: CheckInDTO.self) }
                 } catch {
                     throw APIError.fetchError
                 }
             },
             add: { dto in
+                guard let ref = await collectionRef() else { throw APIError.updateError }
                 do {
-                    let ref = await collectionRef().document(dto.pilgrimageDTO.code)
-                    try ref.setData(from: dto)
+                    let docRef = ref.document(dto.pilgrimageDTO.code)
+                    try docRef.setData(from: dto)
                 } catch {
                     throw APIError.updateError
                 }
             },
             updateCheckedInAt: { code, newDate in
+                guard let ref = await collectionRef() else { throw APIError.updateError }
                 do {
-                    let ref = await collectionRef().document(code)
-                    try await ref.updateData(["checked_in_at": Timestamp(date: newDate)])
+                    try await ref.document(code).updateData(["checked_in_at": Timestamp(date: newDate)])
                 } catch {
                     throw APIError.updateError
                 }
             },
             updateMemo: { code, memo in
+                guard let ref = await collectionRef() else { throw APIError.updateError }
                 do {
-                    let ref = await collectionRef().document(code)
+                    let docRef = ref.document(code)
                     if let memo {
-                        try await ref.updateData(["memo": memo])
+                        try await docRef.updateData(["memo": memo])
                     } else {
-                        try await ref.updateData(["memo": FieldValue.delete()])
+                        try await docRef.updateData(["memo": FieldValue.delete()])
                     }
                 } catch {
                     throw APIError.updateError
@@ -67,12 +70,14 @@ extension CheckInRemoteDataStore: DependencyKey {
         )
     }()
 
-    private static func collectionRef() async -> CollectionReference {
+    private static func collectionRef() async -> CollectionReference? {
         @Dependency(AuthRepository.self) var authRepository
+        @Dependency(RemoteConfigClient.self) var remoteConfigClient
         let documentId: String
         if let user = authRepository.currentUser() {
             documentId = user.uid
         } else {
+            guard remoteConfigClient.isUUIDAccessEnabled() else { return nil }
             documentId = await UIDevice.current.identifierForVendor!.uuidString
         }
         return Firestore.firestore()

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/DebugRemoteConfigClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/DebugRemoteConfigClient.swift
@@ -1,0 +1,8 @@
+//
+//  DebugRemoteConfigClient.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/04/10.
+//
+
+import Foundation

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/DebugRemoteConfigClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/DebugRemoteConfigClient.swift
@@ -5,4 +5,33 @@
 //  Created by k_kudo on 2026/04/10.
 //
 
-import Foundation
+#if DEBUG
+import Dependencies
+import DependenciesMacros
+@preconcurrency import FirebaseRemoteConfig
+
+@DependencyClient
+struct DebugRemoteConfigClient {
+    var lastFetchTime: @Sendable () -> Date?
+    var allConfig: @Sendable () -> [String: String] = { [:] }
+}
+
+extension DebugRemoteConfigClient: DependencyKey {
+    static let liveValue: Self = {
+        let remoteConfig = RemoteConfig.remoteConfig()
+
+        return .init(
+            lastFetchTime: {
+                remoteConfig.lastFetchTime
+            },
+            allConfig: {
+                let pairs = remoteConfig.allKeys(from: .remote)
+                    .map { key in
+                        (key, remoteConfig.configValue(forKey: key).stringValue ?? "(nil)")
+                    }
+                return Dictionary(uniqueKeysWithValues: pairs)
+            }
+        )
+    }()
+}
+#endif

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/RemoteConfigClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/RemoteConfigClient.swift
@@ -1,0 +1,48 @@
+//
+//  RemoteConfigClient.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/04/10.
+//
+
+import Dependencies
+import DependenciesMacros
+@preconcurrency import FirebaseRemoteConfig
+
+@DependencyClient
+struct RemoteConfigClient {
+    /// Remote Config の値をサーバーからフェッチ・アクティベートする
+    var fetchAndActivate: @Sendable () async -> Void
+    /// サインイン促進をスキップ可能か
+    var canDismissSignInPrompt: @Sendable () -> Bool = { true }
+    /// UUID ベースの Firestore 読み取りが有効か
+    var isUUIDAccessEnabled: @Sendable () -> Bool = { true }
+}
+
+extension RemoteConfigClient: DependencyKey {
+    static let liveValue: Self = {
+        let remoteConfig = RemoteConfig.remoteConfig()
+        let settings = RemoteConfigSettings()
+        #if DEBUG
+        settings.minimumFetchInterval = 0
+        #else
+        settings.minimumFetchInterval = 3600
+        #endif
+        remoteConfig.configSettings = settings
+        return .init(
+            fetchAndActivate: {
+                do {
+                    _ = try await remoteConfig.fetchAndActivate()
+                } catch {
+                    // フェッチ失敗時はデフォルト値で動作
+                }
+            },
+            canDismissSignInPrompt: {
+                remoteConfig[.canDismissSignInPrompt] ?? true
+            },
+            isUUIDAccessEnabled: {
+                remoteConfig[.isUUIDAccessEnabled] ?? true
+            }
+        )
+    }()
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/RemoteConfigParameter/RemoteConfigParameterKey.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Data/RemoteConfig/RemoteConfigParameter/RemoteConfigParameterKey.swift
@@ -1,0 +1,36 @@
+//
+//  RemoteConfigParameterKey.swift
+//  nogizaka-pilgrimage
+//
+//  Created by k_kudo on 2026/04/10.
+//
+
+import FirebaseRemoteConfig
+
+// MARK: - RemoteConfigParameterKey
+
+struct RemoteConfigParameterKey<T> {
+    let key: String
+
+    init(_ key: String) {
+        self.key = key
+    }
+}
+
+extension RemoteConfigParameterKey {
+    static var canDismissSignInPrompt: RemoteConfigParameterKey<Bool> { .init("can_dismiss_signin_prompt") }
+    static var isUUIDAccessEnabled: RemoteConfigParameterKey<Bool> { .init("is_uuid_access_enabled") }
+}
+
+// MARK: - RemoteConfig Extension
+
+extension RemoteConfig {
+    func remoteBoolValue(forKey key: String) -> Bool? {
+        let value = configValue(forKey: key)
+        return value.source == .remote ? value.boolValue : nil
+    }
+
+    subscript(key: RemoteConfigParameterKey<Bool>) -> Bool? {
+        remoteBoolValue(forKey: key.key)
+    }
+}

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/Entity/Auth/SignInPromotionContext.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/Entity/Auth/SignInPromotionContext.swift
@@ -8,15 +8,8 @@
 import Foundation
 
 enum SignInPromotionContext: Equatable, Sendable {
-    /// アプリ起動時（スキップ可）
+    /// アプリ起動時のサインイン促進
     case launch
-    /// チェックイン時（スキップ不可）
+    /// チェックイン時のサインイン促進
     case checkIn
-
-    var isDismissible: Bool {
-        switch self {
-        case .launch: return true
-        case .checkIn: return false
-        }
-    }
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/Entity/CheckInError.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/Entity/CheckInError.swift
@@ -10,4 +10,5 @@ import Foundation
 enum CheckInError: Error {
     case notNearby
     case memoTooLong
+    case signInRequired
 }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/UseCase/CheckInUseCase.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Domain/UseCase/CheckInUseCase.swift
@@ -17,10 +17,15 @@ struct CheckInUseCase {
 extension CheckInUseCase: DependencyKey {
     static let liveValue: Self = {
         @Dependency(CheckInRepository.self) var checkInRepository
+        @Dependency(AuthRepository.self) var authRepository
         @Dependency(\.date) var date
 
         return .init(
             execute: { pilgrimage, userCoordinate in
+                guard authRepository.currentUser() != nil else {
+                    throw CheckInError.signInRequired
+                }
+
                 let distanceThreshold = 200.0
                 let userLocation = CLLocation(latitude: userCoordinate.latitude, longitude: userCoordinate.longitude)
                 let pilgrimageLocation = CLLocation(

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Debug/DebugMenuView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Debug/DebugMenuView.swift
@@ -18,6 +18,13 @@ struct DebugMenuView: View {
 
     @Dependency(SignInPromotionClient.self) private var signInPromotionClient
     @Dependency(AuthRepository.self) private var authRepository
+    @Dependency(DebugRemoteConfigClient.self) private var debugRemoteConfigClient
+
+    private var remoteConfigItems: [(key: String, value: String)] {
+        debugRemoteConfigClient.allConfig()
+            .sorted { $0.key < $1.key }
+            .map { (key: $0.key, value: $0.value) }
+    }
 
     private var userDefaultsItems: [(key: String, value: String)] {
         _ = refreshCounter
@@ -43,6 +50,30 @@ struct DebugMenuView: View {
                     Button("表示済みフラグをリセット") {
                         UserDefaults.standard.removeObject(forKey: UserDefaultsKey.lastSignInPromptVersion.rawValue)
                         refreshCounter += 1
+                    }
+                }
+
+                // MARK: - Remote Config
+                Section("Remote Config") {
+                    if let lastFetchTime = debugRemoteConfigClient.lastFetchTime() {
+                        HStack {
+                            Text("lastFetchTime")
+                                .font(.caption)
+                            Spacer()
+                            Text(lastFetchTime.formatted(date: .abbreviated, time: .standard))
+                                .font(.caption)
+                                .foregroundStyle(Color(.secondaryLabel))
+                        }
+                    }
+                    ForEach(remoteConfigItems, id: \.key) { item in
+                        HStack {
+                            Text(item.key)
+                                .font(.caption)
+                            Spacer()
+                            Text(item.value)
+                                .font(.caption)
+                                .foregroundStyle(Color(.secondaryLabel))
+                        }
                     }
                 }
 

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Launch/LaunchViewModel.swift
@@ -25,6 +25,8 @@ final class LaunchViewModel {
     @Dependency(CheckInMigrationClient.self) var checkInMigration
     @ObservationIgnored
     @Dependency(SignInPromotionClient.self) var signInPromotionClient
+    @ObservationIgnored
+    @Dependency(RemoteConfigClient.self) var remoteConfigClient
 
     var pilgrimages: [PilgrimageEntity] = []
     var isLoading = true
@@ -55,6 +57,7 @@ final class LaunchViewModel {
     }
 
     func initialize() async {
+        await remoteConfigClient.fetchAndActivate()
         await checkForUpdate()
         await favoriteMigration.migrateIfNeeded()
         await checkInMigration.migrateIfNeeded()

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/Pilgrimage/Detail/PilgrimageDetailViewModel.swift
@@ -22,8 +22,6 @@ final class PilgrimageDetailViewModel {
     @ObservationIgnored
     @Dependency(NetworkMonitor.self) var networkMonitor
     @ObservationIgnored
-    @Dependency(SignInPromotionClient.self) var signInPromotionClient
-    @ObservationIgnored
     @Dependency(CheckInMigrationClient.self) var checkInMigration
     @ObservationIgnored
     @Dependency(\.date) var date
@@ -81,11 +79,6 @@ final class PilgrimageDetailViewModel {
     }
 
     func checkIn(pilgrimage: PilgrimageEntity, userCoordinate: CLLocationCoordinate2D) async {
-        if signInPromotionClient.shouldShowOnCheckIn() {
-            pendingCheckIn = (pilgrimage, userCoordinate)
-            showSignInPromotion = true
-            return
-        }
         await performCheckIn(pilgrimage: pilgrimage, userCoordinate: userCoordinate)
     }
 
@@ -121,6 +114,9 @@ final class PilgrimageDetailViewModel {
                 checkedInAt: date.now,
                 isOnline: isOnline
             )
+        } catch CheckInError.signInRequired {
+            pendingCheckIn = (pilgrimage, userCoordinate)
+            showSignInPromotion = true
         } catch is CheckInError {
             activeAlert = .notNearbyError
         } catch is APIError {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/SignInPromotion/SignInPromotionView.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/SignInPromotion/SignInPromotionView.swift
@@ -98,7 +98,7 @@ struct SignInPromotionView: View {
                     action: { await viewModel.signInWithApple() }
                 )
 
-                if viewModel.context.isDismissible {
+                if viewModel.isDismissible {
                     Button(String(localized: .signInPromotionSkip)) {
                         viewModel.skip()
                     }

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/SignInPromotion/SignInPromotionViewModel.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Feature/SignInPromotion/SignInPromotionViewModel.swift
@@ -13,8 +13,15 @@ import Foundation
 final class SignInPromotionViewModel {
     @ObservationIgnored
     @Dependency(SignInUseCase.self) private var signInUseCase
+    @ObservationIgnored
+    @Dependency(RemoteConfigClient.self) private var remoteConfigClient
 
     let context: SignInPromotionContext
+
+    var isDismissible: Bool {
+        guard case .launch = context else { return false }
+        return remoteConfigClient.canDismissSignInPrompt()
+    }
     var isSigningIn = false
     var isCompleted = false
     var isSignedIn = false

--- a/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/Auth/SignInPromotionClient.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimage/Utility/Auth/SignInPromotionClient.swift
@@ -13,8 +13,6 @@ import Foundation
 struct SignInPromotionClient {
     /// 起動時にサインイン促進を表示すべきか判定する
     var shouldShowOnLaunch: @Sendable () -> Bool = { false }
-    /// チェックイン時にサインイン促進を表示すべきか判定する
-    var shouldShowOnCheckIn: @Sendable () -> Bool = { false }
     /// サインイン促進を表示済みとしてマークする
     var markPromptShown: @Sendable () -> Void
 }
@@ -23,15 +21,16 @@ extension SignInPromotionClient: DependencyKey {
     static let liveValue: Self = {
         @Dependency(AuthRepository.self) var authRepository
         @Dependency(BuildClient.self) var buildClient
+        @Dependency(RemoteConfigClient.self) var remoteConfigClient
 
         return .init(
             shouldShowOnLaunch: {
                 guard authRepository.currentUser() == nil else { return false }
+                if !remoteConfigClient.canDismissSignInPrompt() {
+                    return true
+                }
                 let lastVersion = UserDefaults.standard.string(forKey: UserDefaultsKey.lastSignInPromptVersion.rawValue)
                 return lastVersion != buildClient.appVersion()
-            },
-            shouldShowOnCheckIn: {
-                authRepository.currentUser() == nil
             },
             markPromptShown: {
                 let version = buildClient.appVersion()

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Domain/UseCase/CheckInUseCaseTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Domain/UseCase/CheckInUseCaseTests.swift
@@ -31,6 +31,27 @@ struct CheckInUseCaseTests {
     /// テスト用の固定日時
     private static let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
 
+    /// テスト用の認証ユーザー
+    private static let testUser = AuthUser(uid: "test-uid", email: "test@example.com", displayName: "テスト")
+
+    // MARK: - サインイン必須
+
+    @Test("未認証ではCheckInError.signInRequiredがスローされる")
+    func execute_notSignedIn_throws() async {
+        await #expect(throws: CheckInError.signInRequired) {
+            try await withDependencies {
+                $0[AuthRepository.self].currentUser = { nil }
+                $0[CheckInRepository.self].addCheckIn = { _, _, _ in }
+                $0.date = .constant(Self.fixedDate)
+            } operation: {
+                try await UseCase.liveValue.execute(
+                    pilgrimage: Self.nogizakaStation,
+                    userCoordinate: Self.nearNogizaka
+                )
+            }
+        }
+    }
+
     // MARK: - チェックイン成功
 
     @Test("チェックイン成功時にcheckedInAtが自動保存される")
@@ -38,6 +59,7 @@ struct CheckInUseCaseTests {
         let savedDate = LockIsolated<Date?>(nil)
 
         try await withDependencies {
+            $0[AuthRepository.self].currentUser = { Self.testUser }
             $0[CheckInRepository.self].addCheckIn = { _, checkedInAt, _ in
                 savedDate.setValue(checkedInAt)
             }
@@ -57,6 +79,7 @@ struct CheckInUseCaseTests {
         let savedMemo = LockIsolated<String??>(nil) // Optional<Optional<String>> で「呼ばれたか」と「値」を区別
 
         try await withDependencies {
+            $0[AuthRepository.self].currentUser = { Self.testUser }
             $0[CheckInRepository.self].addCheckIn = { _, _, memo in
                 savedMemo.setValue(memo)
             }
@@ -74,9 +97,10 @@ struct CheckInUseCaseTests {
     // MARK: - 距離バリデーション
 
     @Test("200m圏外ではCheckInError.notNearbyがスローされる")
-    func execute_notNearby_throws() async throws {
+    func execute_notNearby_throws() async {
         await #expect(throws: CheckInError.notNearby) {
             try await withDependencies {
+                $0[AuthRepository.self].currentUser = { Self.testUser }
                 $0[CheckInRepository.self].addCheckIn = { _, _, _ in }
                 $0.date = .constant(Self.fixedDate)
             } operation: {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Launch/LaunchViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Launch/LaunchViewModelTests.swift
@@ -22,6 +22,7 @@ struct LaunchViewModelTests {
         let migrationCalled = LockIsolated(false)
 
         let viewModel = withDependencies {
+            $0[RemoteConfigClient.self].fetchAndActivate = {}
             $0[BuildClient.self].appVersion = { "1.0.0" }
             $0[FavoriteMigrationClient.self].migrateIfNeeded = {}
             $0[CheckInMigrationClient.self].migrateIfNeeded = {

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Pilgrimage/Detail/PilgrimageDetailViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/Pilgrimage/Detail/PilgrimageDetailViewModelTests.swift
@@ -29,7 +29,6 @@ struct PilgrimageDetailViewModelTests {
         let checkInCalled = LockIsolated(false)
 
         let viewModel = withDependencies {
-            $0[SignInPromotionClient.self].shouldShowOnCheckIn = { false }
             $0[CheckInUseCase.self].execute = { _, _ in
                 checkInCalled.setValue(true)
             }
@@ -45,14 +44,11 @@ struct PilgrimageDetailViewModelTests {
         #expect(viewModel.showSignInPromotion == false)
     }
 
-    @Test("未サインインでcheckInするとサインイン促進が表示される")
-    func checkIn_notSignedIn_showsPromotion() async {
-        let checkInCalled = LockIsolated(false)
-
+    @Test("UseCaseがsignInRequiredをスローするとサインイン促進が表示される")
+    func checkIn_signInRequired_showsPromotion() async {
         let viewModel = withDependencies {
-            $0[SignInPromotionClient.self].shouldShowOnCheckIn = { true }
             $0[CheckInUseCase.self].execute = { _, _ in
-                checkInCalled.setValue(true)
+                throw CheckInError.signInRequired
             }
         } operation: {
             PilgrimageDetailViewModel()
@@ -61,7 +57,6 @@ struct PilgrimageDetailViewModelTests {
         await viewModel.checkIn(pilgrimage: testPilgrimage, userCoordinate: testCoordinate)
 
         #expect(viewModel.showSignInPromotion == true)
-        #expect(checkInCalled.value == false)
     }
 
     // MARK: - サインイン促進完了後
@@ -69,10 +64,14 @@ struct PilgrimageDetailViewModelTests {
     @Test("サインイン成功後にpendingCheckInが実行される")
     func onPromotionCompleted_signedIn_resumesCheckIn() async {
         let checkInCalled = LockIsolated(false)
+        let callCount = LockIsolated(0)
 
         let viewModel = withDependencies {
-            $0[SignInPromotionClient.self].shouldShowOnCheckIn = { true }
             $0[CheckInUseCase.self].execute = { _, _ in
+                let count = callCount.withValue { $0 += 1; return $0 }
+                if count == 1 {
+                    throw CheckInError.signInRequired
+                }
                 checkInCalled.setValue(true)
             }
             $0[CheckInMigrationClient.self].migrateIfNeeded = {}
@@ -82,7 +81,7 @@ struct PilgrimageDetailViewModelTests {
             PilgrimageDetailViewModel()
         }
 
-        // チェックイン試行 → 促進画面表示
+        // チェックイン試行 → signInRequired → 促進画面表示
         await viewModel.checkIn(pilgrimage: testPilgrimage, userCoordinate: testCoordinate)
         #expect(viewModel.showSignInPromotion == true)
 
@@ -96,13 +95,17 @@ struct PilgrimageDetailViewModelTests {
     @Test("サインイン成功後にマイグレーションがチェックインより先に実行される")
     func onPromotionCompleted_signedIn_migratesBeforeCheckIn() async {
         let callOrder = LockIsolated<[String]>([])
+        let callCount = LockIsolated(0)
 
         let viewModel = withDependencies {
-            $0[SignInPromotionClient.self].shouldShowOnCheckIn = { true }
             $0[CheckInMigrationClient.self].migrateIfNeeded = {
                 callOrder.withValue { $0.append("migration") }
             }
             $0[CheckInUseCase.self].execute = { _, _ in
+                let count = callCount.withValue { $0 += 1; return $0 }
+                if count == 1 {
+                    throw CheckInError.signInRequired
+                }
                 callOrder.withValue { $0.append("checkIn") }
             }
             $0[NetworkMonitor.self].monitorNetwork = {}
@@ -122,9 +125,8 @@ struct PilgrimageDetailViewModelTests {
         let checkInCalled = LockIsolated(false)
 
         let viewModel = withDependencies {
-            $0[SignInPromotionClient.self].shouldShowOnCheckIn = { true }
             $0[CheckInUseCase.self].execute = { _, _ in
-                checkInCalled.setValue(true)
+                throw CheckInError.signInRequired
             }
         } operation: {
             PilgrimageDetailViewModel()

--- a/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/SignInPromotion/SignInPromotionViewModelTests.swift
+++ b/nogizaka-pilgrimage/nogizaka-pilgrimageTests/Feature/SignInPromotion/SignInPromotionViewModelTests.swift
@@ -90,15 +90,38 @@ struct SignInPromotionViewModelTests {
         #expect(viewModel.isSignedIn == false)
     }
 
-    // MARK: - context
+    // MARK: - isDismissible
 
-    @Test("launchコンテキストはスキップ可能")
-    func launch_isDismissible() {
-        #expect(SignInPromotionContext.launch.isDismissible == true)
+    @Test("launchコンテキスト + canDismiss=true → スキップ可能")
+    func launch_canDismiss_isDismissible() {
+        let viewModel = withDependencies {
+            $0[RemoteConfigClient.self].canDismissSignInPrompt = { true }
+        } operation: {
+            SignInPromotionViewModel(context: .launch)
+        }
+
+        #expect(viewModel.isDismissible == true)
     }
 
-    @Test("checkInコンテキストはスキップ不可")
+    @Test("launchコンテキスト + canDismiss=false → スキップ不可")
+    func launch_cannotDismiss_isNotDismissible() {
+        let viewModel = withDependencies {
+            $0[RemoteConfigClient.self].canDismissSignInPrompt = { false }
+        } operation: {
+            SignInPromotionViewModel(context: .launch)
+        }
+
+        #expect(viewModel.isDismissible == false)
+    }
+
+    @Test("checkInコンテキストはcanDismissに関わらずスキップ不可")
     func checkIn_isNotDismissible() {
-        #expect(SignInPromotionContext.checkIn.isDismissible == false)
+        let viewModel = withDependencies {
+            $0[RemoteConfigClient.self].canDismissSignInPrompt = { true }
+        } operation: {
+            SignInPromotionViewModel(context: .checkIn)
+        }
+
+        #expect(viewModel.isDismissible == false)
     }
 }


### PR DESCRIPTION
## Summary
- Firebase Remote Configを導入し、`can_dismiss_signin_prompt`・`is_uuid_access_enabled` の2フラグで認証移行フェーズをサーバーサイドから制御可能にした
- チェックイン時のサインイン必須化をUseCase層で常時適用に変更し、UI層のプリチェックを廃止
- DebugMenuにRemote Configの現在値・最終取得時刻の表示を追加

## Test plan
- [ ] Remote Config取得失敗時にデフォルト値（Phase 1相当）で動作すること
- [ ] `can_dismiss_signin_prompt = false` + 未サインイン → 起動時サインイン促進のスキップボタンが非表示になること
- [ ] 未サインイン → チェックインボタン押下でサインイン促進が表示されること
- [ ] `is_uuid_access_enabled = false` + 未サインイン → チェックインデータが空で返ること
- [ ] DebugMenuにRemote Configセクションが表示されること
- [ ] ユニットテストが全てpassすること

close #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)